### PR TITLE
✨ Gesture recognition indication

### DIFF
--- a/Assets/Prefabs/PlayerRig/MR Interaction Setup.prefab
+++ b/Assets/Prefabs/PlayerRig/MR Interaction Setup.prefab
@@ -3847,6 +3847,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _rightHand: {fileID: 8827492844492106989}
   _leftHand: {fileID: 6679902487617635372}
+  _rightHandMaterial: {fileID: 2100000, guid: 61d033f3a51f40647a5458ea14f3b4af, type: 2}
+  _leftHandMaterial: {fileID: 2100000, guid: 61d033f3a51f40647a5458ea14f3b4af, type: 2}
   _allGestures:
   - {fileID: 11400000, guid: 98105de35a6f47945a9bc17659aae264, type: 2}
   - {fileID: 11400000, guid: 6c6e9117b77522e48bf8288bb53e515c, type: 2}
@@ -3865,9 +3867,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9eccb514a7aeb7c4eb130e0b7b09069e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _gestureManager: {fileID: 7497934956184238321}
+  _rightHandMaterial: {fileID: 2100000, guid: 61d033f3a51f40647a5458ea14f3b4af, type: 2}
+  _leftHandMaterial: {fileID: 2100000, guid: 61d033f3a51f40647a5458ea14f3b4af, type: 2}
   _availableSpells:
   - {fileID: 11400000, guid: 1ef0e2ff34d668d4cb4aa300a7fdcca8, type: 2}
-  _gestureManager: {fileID: 7497934956184238321}
 --- !u!1 &2268672708825686388
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Spells/Gesture.cs
+++ b/Assets/Scripts/Spells/Gesture.cs
@@ -8,12 +8,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [SerializeField] internal string _name;
 
         // Left/Right hand shape to create the gesture
-        [SerializeField] internal HandShape _leftHandShape; 
+        [SerializeField] internal HandShape _leftHandShape;
         [SerializeField] internal HandShape _rightHandShape;
 
         // Max distance between the hands in x, y, z direction for the gesture to be recognised
-        [SerializeField] internal float _xHandDistance; 
+        [SerializeField] internal float _xHandDistance;
         [SerializeField] internal float _yHandDistance;
         [SerializeField] internal float _zHandDistance;
+
+        [SerializeField] internal Color _color;
     }
 }

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 1.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 1.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
-  _color: {r: 0, g: 1, b: 0.9836073, a: 0}
+  _color: {r: 0, g: 1, b: 0.9836073, a: 1}

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 1.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 1.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
+  _color: {r: 0, g: 1, b: 0.9836073, a: 0}

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 2.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 2.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
-  _color: {r: 1, g: 0, b: 0, a: 0}
+  _color: {r: 1, g: 0.3810822, b: 0.10849059, a: 1}

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 2.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 2.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
+  _color: {r: 1, g: 0, b: 0, a: 0}

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
-  _color: {r: 1, g: 1, b: 1, a: 0}
+  _color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy.asset
@@ -13,8 +13,9 @@ MonoBehaviour:
   m_Name: Testy Boy
   m_EditorClassIdentifier: 
   _name: Start
-  _leftHandGesture: 0
-  _rightHandGesture: 0
+  _leftHandShape: 0
+  _rightHandShape: 0
   _xHandDistance: 2
   _yHandDistance: 2
   _zHandDistance: 2
+  _color: {r: 1, g: 1, b: 1, a: 0}

--- a/Assets/Scripts/Spells/SequenceManager.cs
+++ b/Assets/Scripts/Spells/SequenceManager.cs
@@ -23,7 +23,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private HandShape _leftHandShape;
         private HandShape _rightHandShape;
         private bool _gestureValidated = false;
-        private bool _sequenceStarted = false;
+        [SerializeField] private bool _sequenceStarted = false;
 
         internal event Action OnSequenceCreated;
         internal event Action OnReset;
@@ -71,15 +71,17 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             if (_currentGesture != null)
             {
-                if (_currentGesture._name == "Start" && _leftHandActive && _rightHandActive)
+                if (_currentGesture._name == "Start" && _leftHandActive && _rightHandActive &&
+                    _currentGesture._leftHandShape == HandShape.Start && _currentGesture._rightHandShape == HandShape.Start)
                 {
+                    print("Why you do thiesssss");
                     _validatedGestures.Clear();
                     OnReset?.Invoke();
                     _sequenceStarted = true;
                 }
-
-                if (_validatedGestures.Count == 0 && _sequenceStarted ||
-                    _validatedGestures[^1] != _currentGesture && _sequenceStarted)
+                print($"{_validatedGestures.Count} {_sequenceStarted}");
+                if (_sequenceStarted && _validatedGestures.Count == 0 ||
+                    _sequenceStarted && _validatedGestures[^1] != _currentGesture)
                 {
                     _validatedGestures.Add(_currentGesture);
                     ChangeColor(_cancellationTokenSource.Token);
@@ -88,8 +90,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
                 if (_validatedGestures.Count == 3)
                 {
-                    _sequenceStarted = false;
                     OnSequenceCreated?.Invoke();
+                    _sequenceStarted = false;
+                    _currentGesture = null;
+                    ValidatedGestures.Clear();
                 }
 
                 _currentGesture = null;
@@ -117,12 +121,12 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             try
             {
-                HandShape handShape = _validatedGestures[^1]._rightHandShape;
+                float delay = 1;
 
                 _rightHandMaterial.SetColor("_MainColor", _currentGesture._color);
                 _leftHandMaterial.SetColor("_MainColor", _currentGesture._color);
 
-                await UniTask.WaitForSeconds(1, cancellationToken: token);
+                await UniTask.WaitForSeconds(delay, cancellationToken: token);
 
                 _rightHandMaterial.SetColor("_MainColor", defaultColor);
                 _leftHandMaterial.SetColor("_MainColor", defaultColor);

--- a/Assets/Scripts/Spells/SequenceManager.cs
+++ b/Assets/Scripts/Spells/SequenceManager.cs
@@ -74,24 +74,21 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 if (_currentGesture._name == "Start" && _leftHandActive && _rightHandActive &&
                     _currentGesture._leftHandShape == HandShape.Start && _currentGesture._rightHandShape == HandShape.Start)
                 {
-                    print("Why you do thiesssss");
                     _validatedGestures.Clear();
                     OnReset?.Invoke();
                     _sequenceStarted = true;
                 }
-                print($"{_validatedGestures.Count} {_sequenceStarted}");
+
                 if (_sequenceStarted && _validatedGestures.Count == 0 ||
                     _sequenceStarted && _validatedGestures[^1] != _currentGesture)
                 {
                     _validatedGestures.Add(_currentGesture);
                     ChangeColor(_cancellationTokenSource.Token);
-                    Debug.Log("Validated Gesture: " + _currentGesture._name);
                 }
 
                 if (_validatedGestures.Count == 3)
                 {
                     OnSequenceCreated?.Invoke();
-                    _sequenceStarted = false;
                     _currentGesture = null;
                     ValidatedGestures.Clear();
                 }
@@ -121,15 +118,23 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             try
             {
-                float delay = 1;
+                if (_validatedGestures.Count < 3)
+                {
+                    float delay = 1;
 
-                _rightHandMaterial.SetColor("_MainColor", _currentGesture._color);
-                _leftHandMaterial.SetColor("_MainColor", _currentGesture._color);
+                    _rightHandMaterial.SetColor("_MainColor", _currentGesture._color);
+                    _leftHandMaterial.SetColor("_MainColor", _currentGesture._color);
 
-                await UniTask.WaitForSeconds(delay, cancellationToken: token);
+                    await UniTask.WaitForSeconds(delay, cancellationToken: token);
 
-                _rightHandMaterial.SetColor("_MainColor", defaultColor);
-                _leftHandMaterial.SetColor("_MainColor", defaultColor);
+                    _rightHandMaterial.SetColor("_MainColor", defaultColor);
+                    _leftHandMaterial.SetColor("_MainColor", defaultColor);
+                }
+                else
+                {
+                    _rightHandMaterial.SetColor("_MainColor", _currentGesture._color);
+                    _leftHandMaterial.SetColor("_MainColor", _currentGesture._color);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/Assets/Scripts/Spells/SequenceManager.cs
+++ b/Assets/Scripts/Spells/SequenceManager.cs
@@ -89,7 +89,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 if (_validatedGestures.Count == 3)
                 {
                     OnSequenceCreated?.Invoke();
-                    _currentGesture = null;
+                    _sequenceStarted = false;
                     ValidatedGestures.Clear();
                 }
 
@@ -118,7 +118,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             try
             {
-                if (_validatedGestures.Count < 3)
+                if (_validatedGestures.Count < 3 && _validatedGestures.Count > 0)
                 {
                     float delay = 1;
 

--- a/Assets/Scripts/Spells/SequenceManager.cs
+++ b/Assets/Scripts/Spells/SequenceManager.cs
@@ -23,7 +23,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private HandShape _leftHandShape;
         private HandShape _rightHandShape;
         private bool _gestureValidated = false;
-        [SerializeField] private bool _sequenceStarted = false;
+        private bool _sequenceStarted = false;
 
         internal event Action OnSequenceCreated;
         internal event Action OnReset;

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -62,7 +62,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                     _currentSpell = null;
                     _canCast = false;
                     SpellWrongIndication(_cancellationTokenSource.Token);
-
                 }
         }
 
@@ -79,7 +78,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
                     _rightHandMaterial.SetColor("_MainColor", Color.red);
                     _leftHandMaterial.SetColor("_MainColor", Color.red);
-                    print("wrong");
+
                     await UniTask.WaitForSeconds(delay, cancellationToken: token);
 
                     _rightHandMaterial.SetColor("_MainColor", defaultColor);

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -1,15 +1,32 @@
+using Cysharp.Threading.Tasks;
+using System;
 using System.Linq;
+using System.Threading;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Spells
 {
     internal class SpellManager : MonoBehaviour
     {
-        [SerializeField] private Spell[] _availableSpells;
         [SerializeField] private SequenceManager _gestureManager;
+        [SerializeField] private Material _rightHandMaterial;
+        [SerializeField] private Material _leftHandMaterial;
+        [SerializeField] private Spell[] _availableSpells;
 
         private Spell _currentSpell;
+        private CancellationTokenSource _cancellationTokenSource;
+        private Color defaultColor;
         private bool _canCast = false;
+
+        private void Awake()
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void Start()
+        {
+            defaultColor = _rightHandMaterial.GetColor("_MainColor");
+        }
 
         private void OnEnable()
         {
@@ -21,6 +38,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _gestureManager.OnSequenceCreated -= ValidateSequence;
             _gestureManager.OnReset -= HandleReset;
+
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
         }
 
         private void SetSpell(Spell spell)
@@ -37,6 +57,39 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                     SetSpell(spell);
                     Debug.Log("HEEEEEEEEEEEEEEEEEEY" + spell.name);
                 }
+                else
+                {
+                    _currentSpell = null;
+                    _canCast = false;
+                    SpellWrongIndication(_cancellationTokenSource.Token);
+
+                }
+        }
+
+        private async void SpellWrongIndication(CancellationToken token)
+        {
+            try
+            {
+                float delay = 0.5f;
+                int loopAmount = 2;
+
+                for (int i = 0; i < loopAmount; i++)
+                {
+                    await UniTask.WaitForSeconds(delay, cancellationToken: token);
+
+                    _rightHandMaterial.SetColor("_MainColor", Color.red);
+                    _leftHandMaterial.SetColor("_MainColor", Color.red);
+                    print("wrong");
+                    await UniTask.WaitForSeconds(delay, cancellationToken: token);
+
+                    _rightHandMaterial.SetColor("_MainColor", defaultColor);
+                    _leftHandMaterial.SetColor("_MainColor", defaultColor);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                Debug.LogError("SpellWrongIndication was canceled");
+            }
         }
 
         internal void HandleReset()


### PR DESCRIPTION
## Content

Hands now change color to the gesture's color (gesture now has a color field), to show a gesture has been recognised. only after a sequence is completed it will show whether a spell is recognised or not.

## Changes

### Added
`File` : Was created. You can add the purpose here.

### Updated
`Assets/Scripts/Spells/Gesture.cs` : Was updated / renamed. Now has a color field.
`Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 1.asset` : Was updated / renamed. Color has been added.
`Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy 2.asset` : Was updated / renamed. Color has been added.
`Assets/Scripts/Spells/ScriptableObjects/Gestures/Testy Boy.asset` : Was updated / renamed. Color has been added.
`Assets/Scripts/Spells/SequenceManager.cs` : Was updated / renamed. Added functionality to change hands to .
`Assets/Scripts/Spells/SpellManager.cs` : Was updated / renamed. Added functionality to indicate if a spell sequence is wrong.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Make thubs up gesture, if correctly done hands turns white.
2. Make a fist gesture, if correctly done turns orange, or make palm up gesture, turns cyan when done correctly.
3. Make a fist gesture, if correctly done turns orange, or make palm up gesture, turns cyan when done correctly.
4. If order was thumbs up, fist, palm up: hands should stay cyan. If order was different hands should flash red twice.

|Correct Sequence|Wrong Sequence|
|:-:|:-:|
|![Sequence Correct](https://github.com/user-attachments/assets/1cc7c408-3b8b-4b88-8a14-9c555f6804dd)|![Sequence Wrong Smaller](https://github.com/user-attachments/assets/66e4e112-8a15-4b20-8d1e-4453de22b9e3)|

Closes #34 
