### PR TITLE
✨ Feature/interactables system wind

### DIFF
--- a/Assets/Scripts/Interactables/Wind/Blowable.cs
+++ b/Assets/Scripts/Interactables/Wind/Blowable.cs
@@ -1,9 +1,40 @@
+using System;
+using UnityEngine;
+
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 {
 	internal class Blowable : WindInteractable
 	{
+		// Duration something stays in the blown state
+		[SerializeField] private float _blownDuration = 1f;
+
+		// Bool to decide if something stays blown or not.
+		[SerializeField] private bool _temporaryBlown;
+
+		private float _elapsedTime;
+		// Event to indicate an object is hit with the wind spell, thus blown :)
+		internal event Action<bool> onObjectBlown; 
+
+		private void FixedUpdate()
+		{
+			if (_isBlown && _temporaryBlown)
+			{
+				_elapsedTime += Time.fixedDeltaTime;
+				if (_elapsedTime >= _blownDuration) EndBlown();
+			}
+		}
+
 		internal override void Blown()
 		{
+			_isBlown = true;
+			onObjectBlown?.Invoke(_isBlown);
+			_elapsedTime = 0f;
+		}
+
+		private void EndBlown()
+		{
+			_isBlown = false;
+			onObjectBlown?.Invoke(_isBlown);
 		}
 	}
 }

--- a/Assets/Scripts/Interactables/Wind/Blowable.cs
+++ b/Assets/Scripts/Interactables/Wind/Blowable.cs
@@ -1,6 +1,9 @@
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 {
-	internal abstract class Blowable : WindInteractable
+	internal class Blowable : WindInteractable
 	{
+		internal override void Blown()
+		{
+		}
 	}
 }

--- a/Assets/Scripts/Interactables/Wind/Turnable.cs
+++ b/Assets/Scripts/Interactables/Wind/Turnable.cs
@@ -1,68 +1,44 @@
-using System;
-using System.Threading;
-using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 {
 	internal class Turnable : WindInteractable
 	{
-		[SerializeField] private bool _isTurning;
 		[SerializeField] private float _turnDuration = 1f;
 		[SerializeField] private Transform _targetTransform;
 		[SerializeField] private Vector3 _rotationDegrees;
-		private CancellationTokenSource _cancellationTokenSource;
+		private float _elapsedTime;
+		private Quaternion _startRotation;
+		private Quaternion _targetRotation;
 
-		internal override void Awake()
+		// No need to override the awake and ondestroy, as theres no Unitask, so they will simply do the base implementation
+		private void FixedUpdate()
 		{
-			base.Awake();
-			_cancellationTokenSource = new CancellationTokenSource();
-		}
-
-		internal override void OnDestroy()
-		{
-			base.OnDestroy();
-			_cancellationTokenSource.Cancel();
-			_cancellationTokenSource.Dispose();
-		}
-
-		private async void Turn(CancellationToken token)
-		{
-			try
-			{
-				var startRotation = _targetTransform.rotation;
-
-				//set a custom degrees in the editor so it will take x amount of seconds to reach this rotation
-				var targetRotation = Quaternion.Euler(_rotationDegrees);
-				var elaspedTime = 0f;
-
-				while (elaspedTime < _turnDuration)
-				{
-					if (token.IsCancellationRequested) throw new OperationCanceledException();
-					elaspedTime += Time.deltaTime;
-					var t = Mathf.Clamp01(elaspedTime / _turnDuration);
-					_targetTransform.rotation = Quaternion.Slerp(startRotation, _targetTransform.rotation, t);
-
-					await UniTask.Yield(token);
-				}
-
-				_targetTransform.rotation = targetRotation;
-				_isTurning = false;
-				_isBlown = false;
-			}
-			catch (OperationCanceledException)
-			{
-				Debug.LogError("turning thingamajing is canceled");
-			}
+			if (_isBlown) Turn();
 		}
 
 		internal override void Blown()
 		{
-			Debug.Log("hit the turning thingamajing");
+			// If there are any issues, you can wrap this in an if (!_isBlown).
+			// This is not done so if the player casts multiple spells, it won't stop with the logic of only 1
+			Debug.Log("hit the turning thingamajig");
 			_isBlown = true;
-			_isTurning = true;
-			Turn(_cancellationTokenSource.Token);
-			Debug.Log("Object is turning");
+
+			_startRotation = _targetTransform.rotation;
+			_targetRotation = _startRotation * Quaternion.Euler(_rotationDegrees);
+			_elapsedTime = 0f;
+
+			Debug.Log("object is turning");
+		}
+
+		private void Turn()
+		{
+			_elapsedTime += Time.deltaTime;
+			var t = Mathf.Clamp01(_elapsedTime / _turnDuration);
+
+			_targetTransform.rotation = Quaternion.Slerp(_startRotation, _targetRotation, t);
+
+			if (t >= 1f) _isBlown = false;
 		}
 	}
 }

--- a/Assets/Scripts/Interactables/Wind/Turnable.cs
+++ b/Assets/Scripts/Interactables/Wind/Turnable.cs
@@ -21,14 +21,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 		{
 			// If there are any issues, you can wrap this in an if (!_isBlown).
 			// This is not done so if the player casts multiple spells, it won't stop with the logic of only 1
-			Debug.Log("hit the turning thingamajig");
 			_isBlown = true;
 
 			_startRotation = _targetTransform.rotation;
 			_targetRotation = _startRotation * Quaternion.Euler(_rotationDegrees);
 			_elapsedTime = 0f;
-
-			Debug.Log("object is turning");
 		}
 
 		private void Turn()

--- a/Assets/Scripts/Interactables/Wind/Turnable.cs
+++ b/Assets/Scripts/Interactables/Wind/Turnable.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
+{
+	internal class Turnable : WindInteractable
+	{
+		[SerializeField] private bool _isTurning;
+		[SerializeField] private float _turnDuration = 1f;
+		[SerializeField] private Transform _targetTransform;
+		[SerializeField] private Vector3 _rotationDegrees;
+		private CancellationTokenSource _cancellationTokenSource;
+
+		internal override void Awake()
+		{
+			base.Awake();
+			_cancellationTokenSource = new CancellationTokenSource();
+		}
+
+		internal override void OnDestroy()
+		{
+			base.OnDestroy();
+			_cancellationTokenSource.Cancel();
+			_cancellationTokenSource.Dispose();
+		}
+
+		private async void Turn(CancellationToken token)
+		{
+			try
+			{
+				var startRotation = _targetTransform.rotation;
+
+				//set a custom degrees in the editor so it will take x amount of seconds to reach this rotation
+				var targetRotation = Quaternion.Euler(_rotationDegrees);
+				var elaspedTime = 0f;
+
+				while (elaspedTime < _turnDuration)
+				{
+					if (token.IsCancellationRequested) throw new OperationCanceledException();
+					elaspedTime += Time.deltaTime;
+					var t = Mathf.Clamp01(elaspedTime / _turnDuration);
+					_targetTransform.rotation = Quaternion.Slerp(startRotation, _targetTransform.rotation, t);
+
+					await UniTask.Yield(token);
+				}
+
+				_targetTransform.rotation = targetRotation;
+				_isTurning = false;
+				_isBlown = false;
+			}
+			catch (OperationCanceledException)
+			{
+				Debug.LogError("turning thingamajing is canceled");
+			}
+		}
+
+		internal override void Blown()
+		{
+			Debug.Log("hit the turning thingamajing");
+			_isBlown = true;
+			_isTurning = true;
+			Turn(_cancellationTokenSource.Token);
+			Debug.Log("Object is turning");
+		}
+	}
+}

--- a/Assets/Scripts/Interactables/Wind/Turnable.cs.meta
+++ b/Assets/Scripts/Interactables/Wind/Turnable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e65a360862f9c54fb555a695d96ef2a

--- a/Assets/Scripts/Interactables/Wind/WindInteractable.cs
+++ b/Assets/Scripts/Interactables/Wind/WindInteractable.cs
@@ -1,7 +1,12 @@
+using System;
+using UnityEngine;
+
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 {
 	internal abstract class WindInteractable : Interactables
 	{
+		[SerializeField] internal bool isBlown;
+
 		internal override void Awake()
 		{
 			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
@@ -11,9 +16,24 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 		{
 			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
 		}
+		
+		internal event Action<bool> onBlown; 
 
 		internal override void HandleSpellReceived(string spellType)
 		{
+			Debug.Log("Some spell hit");
+			switch (spellType)
+			{
+				case "Debug":
+					// Logic for casting a fire spell
+					break;
+				case "Wind":
+					// Implement the spinning of the fan. Boxes and things are not required, as the wind spell will have force
+					break;
+				default: throw new NotImplementedException();
+			}
 		}
+		
+		internal abstract void HandleBlown();
 	}
 }

--- a/Assets/Scripts/Interactables/Wind/WindInteractable.cs
+++ b/Assets/Scripts/Interactables/Wind/WindInteractable.cs
@@ -6,8 +6,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 	internal abstract class WindInteractable : Interactables
 	{
 		[SerializeField] internal bool _isBlown;
-		internal event Action<bool> onBlown;
 
+		internal event Action<bool> onBlown;
+		
 		internal override void Awake()
 		{
 			_spellReceiver.OnSpellReceived += HandleSpellReceived;
@@ -29,6 +30,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 					break;
 				case "Wind":
 					// Implement the spinning of the fan. Boxes and things are not required, as the wind spell will have force
+					Blown();
+					onBlown?.Invoke(_isBlown);
 					break;
 				default: throw new NotImplementedException();
 			}

--- a/Assets/Scripts/Interactables/Wind/WindInteractable.cs
+++ b/Assets/Scripts/Interactables/Wind/WindInteractable.cs
@@ -5,27 +5,27 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 {
 	internal abstract class WindInteractable : Interactables
 	{
-		[SerializeField] internal bool isBlown;
+		[SerializeField] internal bool _isBlown;
+		internal event Action<bool> onBlown;
 
 		internal override void Awake()
 		{
-			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
+			_spellReceiver.OnSpellReceived += HandleSpellReceived;
 		}
 
 		internal override void OnDestroy()
 		{
 			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
 		}
-		
-		internal event Action<bool> onBlown; 
 
 		internal override void HandleSpellReceived(string spellType)
 		{
-			Debug.Log("Some spell hit");
+			Debug.Log("Some wind spell hit");
 			switch (spellType)
 			{
 				case "Debug":
-					// Logic for casting a fire spell
+					Blown();
+					onBlown?.Invoke(_isBlown);
 					break;
 				case "Wind":
 					// Implement the spinning of the fan. Boxes and things are not required, as the wind spell will have force
@@ -33,7 +33,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Wind
 				default: throw new NotImplementedException();
 			}
 		}
-		
-		internal abstract void HandleBlown();
+
+		internal abstract void Blown();
 	}
 }

--- a/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -503,6 +503,28 @@ MonoBehaviour:
   company: Unity Technologies
   priority: 0
   required: 0
+--- !u!114 &-3601813509738894493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b5a1f07dc5afe854f9f12a4194aca3fb, type: 3}
+  m_Name: WebGL
+  m_EditorClassIdentifier: 
+  features:
+  - {fileID: 1098386262618696016}
+  m_renderMode: 1
+  m_autoColorSubmissionMode: 1
+  m_colorSubmissionModes:
+    m_List: 00000000
+  m_depthSubmissionMode: 0
+  m_optimizeBufferDiscards: 0
+  m_symmetricProjection: 0
+  m_foveatedRenderingApi: 0
 --- !u!114 &-3477405544128104927
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -830,11 +852,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f0ebc320a151d3408ea1e9fce54d40e, type: 3}
   m_Name: OpenXR Package Settings
   m_EditorClassIdentifier: 
-  Keys: 01000000070000000e000000
+  Keys: 01000000070000000e0000000d000000
   Values:
   - {fileID: 4730841759217965630}
   - {fileID: 905633603019564632}
   - {fileID: 6397117422523670401}
+  - {fileID: -3601813509738894493}
 --- !u!114 &184251549182097694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -964,6 +987,26 @@ MonoBehaviour:
   m_optimizeBufferDiscards: 0
   m_symmetricProjection: 0
   m_foveatedRenderingApi: 0
+--- !u!114 &1098386262618696016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b213d3e3c7f3109449eb46a4c8ee42f0, type: 3}
+  m_Name: XrPerformanceSettingsFeature WebGL
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: XR Performance Settings
+  version: 1.0.0
+  featureIdInternal: com.unity.openxr.feature.extension.performance_settings
+  openxrExtensionStrings: XR_EXT_performance_settings
+  company: Unity
+  priority: 0
+  required: 0
 --- !u!114 &1688128856327725665
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Content
The WindInteractable system has been implemented. There is a turnable script which can turn an object when hit by a spell, and a blowable script which can change its state and invoke an event on hit.

## Changes
<!-- Tip: You can just copy paste the below lines, or remove them as needed. -->
### Added
`Turnable.cs` : Was created with proper functionality

### Updated
`Blowable.cs` : Was updated with the proper functionality.
`WindInteractable.cs` : Was updated to implement all the inheriting classes.

## Testing
The feature / Bugfix can be testing by following these steps:

1. Add an empty gameobject in the fire puzzle scene (to have the debug spell fired on it)
2. Give this gameobject 2 children, 1: the spellreceiver prefab, 2: the object you wanna test (can be anything)
![image](https://github.com/user-attachments/assets/41c83525-e647-4dea-8b6e-67aa4aa365ce)
3. Make sure the spellreceiver has a hitbox thats trigger, and make sure the object you wanna test, does not have a trigger hitbox!.
4. Make sure the object is in the path of the debug spell (I placed it in front of the vines)
5. In the empty gameobject drag the corresponding gameobjects into the serialized fields
![image](https://github.com/user-attachments/assets/ce72aa98-d6fa-4bf6-828e-deda17caa86b)
6. Add degrees for turnable and mess around with the other variables to fulfill your desires.


![windGif](https://github.com/user-attachments/assets/12110683-56df-47ea-9ea3-456aa960accb)

<!-- If there is no issue, simply remove it. -->
Closes #69 
