### PR TITLE
✨Feature/interactables system earth

### DIFF
--- a/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
+++ b/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
@@ -6,8 +5,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 	internal abstract class EarthInteractable : Interactables
 	{
 		[SerializeField] internal bool _isTouched;
-		internal event Action<bool> onTouched;
-		
+		[SerializeField] internal bool _isGrowSpellActive;
+		[SerializeField] internal bool _isShrinkSpellActive;
+
 		internal override void Awake()
 		{
 			_spellReceiver.OnSpellReceived += HandleSpellReceived;
@@ -18,6 +18,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
 		}
 
+		//Basically serves as the oncollisionenter as this is an empty gameobject 
 		internal override void HandleSpellReceived(string spellType)
 		{
 			Debug.Log("Earth spell hit");
@@ -26,11 +27,16 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			{
 				case "Debug":
 					Touched();
-					onTouched?.Invoke(_isTouched);
-					break;	
-				case "Earth":
+					//Use the editor for this
+					//Select the boolean isgrowspellactive or isshrinkspellactive before it hits!
+					break;
+				case "Grow":
+					_isGrowSpellActive = true;
 					Touched();
-					onTouched?.Invoke(_isTouched);
+					break;
+				case "Shrink":
+					_isShrinkSpellActive = true;
+					Touched();
 					break;
 			}
 		}

--- a/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
+++ b/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
@@ -4,7 +4,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
 	internal abstract class EarthInteractable : Interactables
 	{
-		[SerializeField] internal bool _isTouched;
 		[SerializeField] internal bool _isGrowSpellActive;
 		[SerializeField] internal bool _isShrinkSpellActive;
 

--- a/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
+++ b/Assets/Scripts/Interactables/Earth/EarthInteractable.cs
@@ -1,10 +1,16 @@
+using System;
+using UnityEngine;
+
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
 	internal abstract class EarthInteractable : Interactables
 	{
+		[SerializeField] internal bool _isTouched;
+		internal event Action<bool> onTouched;
+		
 		internal override void Awake()
 		{
-			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
+			_spellReceiver.OnSpellReceived += HandleSpellReceived;
 		}
 
 		internal override void OnDestroy()
@@ -14,6 +20,21 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 
 		internal override void HandleSpellReceived(string spellType)
 		{
+			Debug.Log("Earth spell hit");
+
+			switch (spellType)
+			{
+				case "Debug":
+					Touched();
+					onTouched?.Invoke(_isTouched);
+					break;	
+				case "Earth":
+					Touched();
+					onTouched?.Invoke(_isTouched);
+					break;
+			}
 		}
+
+		internal abstract void Touched();
 	}
 }

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -54,7 +54,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			}
 
 			_isGrowSpellActive = false;
-			_isTouched = false;
 		}
 
 		private void ShrinkObject()
@@ -72,7 +71,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			}
 
 			_isShrinkSpellActive = false;
-			_isTouched = false;
 		}
 	}
 }

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -1,66 +1,78 @@
-using System;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
-    internal class Resizable : EarthInteractable
-    {
-        [SerializeField] private Vector3 _initialScale;
-        [SerializeField] private Transform _targetObject;
-        [SerializeField] private Vector3[] _premadeSizes;
-        [SerializeField] private bool _usesPremadeSizes;
-        [SerializeField, Range(0f, 2f)] private float _resizeValue;
+	internal class Resizable : EarthInteractable
+	{
+		[SerializeField] private Vector3 _initialSize;
+		[SerializeField] private Vector3 _shrinkSize;
+		[SerializeField] private Vector3 _growSize;
 
-        internal override void Awake()
-        {
-            base.Awake();
-            _initialScale = _targetObject.localScale;
-           
-        }
+		[SerializeField] private Transform _targetObject;
 
-        internal override void Touched()
-        {
-            _isTouched = true;
-            _targetObject.localScale = _initialScale;
-        }
+		[SerializeField] private bool _shrunk;
+		[SerializeField] private bool _grown;
 
-        private void OnValidate()
-        {
-            ResizeObjectInEditor();
-        }
+		internal override void Awake()
+		{
+			//Sorry, but this was necessary for now, if you have something better, feel free to say so :)
 
-        //Just for testing atm, still trying to figure out how the hell I do this
-        private void ResizeObjectInEditor()
-        {
-            if (_targetObject == null) return;
+			base.Awake();
+			_initialSize = _targetObject.localScale;
 
-            Vector3 newScale = _initialScale * _resizeValue;
+			if (_shrunk)
+				_targetObject.localScale = _shrinkSize;
+			else if (_grown)
+				_targetObject.localScale = _growSize;
+		}
 
-            if (_usesPremadeSizes && _premadeSizes.Length > 0)
-            {
-                newScale = FindClosestPremadeSize(newScale);
-            }
+		internal override void Touched()
+		{
+			ResizeObject();
+		}
 
-            _targetObject.localScale = newScale;
-        }
+		private void ResizeObject()
+		{
+			if (_isGrowSpellActive && !_grown)
+				GrowObject();
 
-        //Doesn't work properly yet
-        private Vector3 FindClosestPremadeSize(Vector3 targetScale)
-        {
-            Vector3 closestSize = _premadeSizes[0];
-            float closestDistance = Vector3.Distance(targetScale, closestSize);
+			else if (_isShrinkSpellActive && !_shrunk)
+				ShrinkObject();
+		}
 
-            foreach (Vector3 size in _premadeSizes)
-            {
-                float distance = Vector3.Distance(targetScale, size);
-                if (distance < closestDistance)
-                {
-                    closestSize = size;
-                    closestDistance = distance;
-                }
-            }
+		private void GrowObject()
+		{
+			if (_shrunk)
+			{
+				_targetObject.localScale = _initialSize;
+				_shrunk = false;
+			}
+			else
+			{
+				_targetObject.localScale = _growSize;
+				_grown = true;
+			}
 
-            return closestSize;
-        }
-    }
+			_isGrowSpellActive = false;
+			_isTouched = false;
+		}
+
+		private void ShrinkObject()
+		{
+			if (_grown)
+			{
+				_targetObject.localScale = _initialSize;
+				_grown = false;
+			}
+
+			else
+			{
+				_targetObject.localScale = _shrinkSize;
+				_shrunk = true;
+			}
+
+			_isShrinkSpellActive = false;
+			_isTouched = false;
+		}
+	}
 }

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -1,6 +1,66 @@
+using System;
+using UnityEngine;
+
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
-	internal abstract class Resizable : Interactables
-	{
-	}
+    internal class Resizable : EarthInteractable
+    {
+        [SerializeField] private Vector3 _initialScale;
+        [SerializeField] private Transform _targetObject;
+        [SerializeField] private Vector3[] _premadeSizes;
+        [SerializeField] private bool _usesPremadeSizes;
+        [SerializeField, Range(0f, 2f)] private float _resizeValue;
+
+        internal override void Awake()
+        {
+            base.Awake();
+            _initialScale = _targetObject.localScale;
+           
+        }
+
+        internal override void Touched()
+        {
+            _isTouched = true;
+            _targetObject.localScale = _initialScale;
+        }
+
+        private void OnValidate()
+        {
+            ResizeObjectInEditor();
+        }
+
+        //Just for testing atm, still trying to figure out how the hell I do this
+        private void ResizeObjectInEditor()
+        {
+            if (_targetObject == null) return;
+
+            Vector3 newScale = _initialScale * _resizeValue;
+
+            if (_usesPremadeSizes && _premadeSizes.Length > 0)
+            {
+                newScale = FindClosestPremadeSize(newScale);
+            }
+
+            _targetObject.localScale = newScale;
+        }
+
+        //Doesn't work properly yet
+        private Vector3 FindClosestPremadeSize(Vector3 targetScale)
+        {
+            Vector3 closestSize = _premadeSizes[0];
+            float closestDistance = Vector3.Distance(targetScale, closestSize);
+
+            foreach (Vector3 size in _premadeSizes)
+            {
+                float distance = Vector3.Distance(targetScale, size);
+                if (distance < closestDistance)
+                {
+                    closestSize = size;
+                    closestDistance = distance;
+                }
+            }
+
+            return closestSize;
+        }
+    }
 }


### PR DESCRIPTION
## Content

The earth interactable is now functional. You can resize objects using the debug spell and the actual spells (when implemented). 
At the moment the debug spell will suffice

## Changes

### Updated
`EarthInteractable.cs` : Was updated to work with the grow/ shrink spell
`Resizable.cs` : Was updated to grow and shrink objects according to the spell

## Testing

The feature / Bugfix can be testing by following these steps:

1. Open the fire puzzle test room, the same which was used to test the wind and fire interactables, so the greybox variant.
2. Put a cube in front of the vines so the debug spell will hit it.
3. Add a resizable to the cube, and give it a spell receiver child (make sure the hitbox of this is slightly larger than the cube)
4. Drag the objects in the editor accordingly
![{363C060D-87B6-4467-80F2-E027417F4458}](https://github.com/user-attachments/assets/241f6d2a-ae81-4552-a645-4681d441fcb7)
5. Enter the desired scale sizes (if you have an object that's already grown, it should have the "grown" boolean and the other way around for one that's shrunk). "Initial Size" is the size of an object that's not shrunk or grown, just default size.
![{54E21476-708C-4D6F-9389-59DADD33AE22}](https://github.com/user-attachments/assets/9480ce6a-e9b8-46c0-bb27-8662952b7f13)
7. If you want to test the grow spell, you select "Is Grow Spell Active" and "Is Shrink Spell Active" if you want to test the shrink spell. Note that this bool will be disabled once hit by a spell.
8. You can also make the object shrunk/ grown by default which will change the size.
![Grow](https://github.com/user-attachments/assets/77edfa6a-a7ae-449a-8d71-b7159ea2527e)


Closes #70 
