### PR TITLE
✨ Earth puzzle prototype

### DIFF
--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -12,7 +12,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 
 		[SerializeField] private bool _shrunk;
 		[SerializeField] private bool _grown;
-
+		
+		public bool Shrunk => _shrunk;
+        public bool Grown => _grown;
+        
 		internal override void Awake()
 		{
 			//Sorry, but this was necessary for now, if you have something better, feel free to say so :)

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
@@ -12,6 +13,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 
 		[SerializeField] private bool _shrunk;
 		[SerializeField] private bool _grown;
+
+		internal event Action onSizeChanged;
 		
 		public bool Shrunk => _shrunk;
         public bool Grown => _grown;
@@ -57,6 +60,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			}
 
 			_isGrowSpellActive = false;
+            onSizeChanged?.Invoke();
 		}
 
 		private void ShrinkObject()
@@ -74,6 +78,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 			}
 
 			_isShrinkSpellActive = false;
+            onSizeChanged?.Invoke();
 		}
 	}
 }

--- a/Assets/Scripts/Puzzle/EarthRoom.meta
+++ b/Assets/Scripts/Puzzle/EarthRoom.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4772b823d683ed14c95d5ee5f1bbac47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
@@ -1,0 +1,50 @@
+using System;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Earth;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
+{
+    public class EarthGateChecker : MonoBehaviour
+    {
+        [SerializeField] private Resizable[] _resizableBlocks;
+
+        private void Awake()
+        {
+            foreach (var resizable in _resizableBlocks)
+            {
+                if (resizable != null)
+                    resizable.onSizeChanged += CheckGateStatus;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var resizable in _resizableBlocks)
+            {
+                if (resizable != null)
+                    resizable.onSizeChanged -= CheckGateStatus;
+            }
+        }
+
+        private void CheckGateStatus()
+        {
+            if (AreAllBlocksGrown())
+                //Later implementation of Loes' animation
+                Debug.Log("Open the gate");
+        }
+
+        private bool AreAllBlocksGrown()
+        {
+            foreach (var resizable in _resizableBlocks)
+            {
+                if (resizable == null || !resizable.Grown)
+                {
+                    Debug.Log("Not all are grown");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs.meta
+++ b/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 306da5f6778721b44bd6e1e1cf89d194

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -40,9 +40,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
                 }
 
                 if (previousState != _shieldFits)
-                {
                     onShieldFitChanged?.Invoke();
-                }
+                
+                if (_shieldFits)
+                    //Just disable for now, could have an extra statement checking if the user still has it grabbed
+                    _targetShield.SetActive(false);
             }
         }
     }

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -12,6 +12,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
         [SerializeField] private bool _shieldFits;
         //Each shield is different so you should add the correct shield here
         [SerializeField] private GameObject _targetShield;
+        [SerializeField] private Resizable _targetResizable;
         
         public bool ShieldFits => _shieldFits;
         //Action so it doesn't need to constantly verify in update
@@ -19,11 +20,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
 
         private void OnTriggerEnter(Collider other)
         {
-            if (other.CompareTag(_shieldTag) && other.TryGetComponent(out Resizable resizable) && other.gameObject == _targetShield)
+            if (other.CompareTag(_shieldTag) && other.gameObject == _targetShield)
             {
                 bool previousState = _shieldFits;
 
-                switch ((resizable.Shrunk, resizable.Grown))
+                switch ((_targetResizable.Shrunk, _targetResizable.Grown))
                 {
                     case (true, false):
                         Debug.Log("Shield is shrunk");
@@ -48,6 +49,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
                 if (_shieldFits)
                     //Just disable for now, could have an extra statement checking if the user still has it grabbed
                     _targetShield.SetActive(false);
+                else
+                {
+                    //Placeholder debug log as requested
+                    Debug.Log("Shield doesn't fit");
+                }
             }
         }
     }

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -11,7 +11,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
         [SerializeField] private bool _checkForGrown;
         [SerializeField] private bool _shieldFits;
         //Each shield is different so you should add the correct shield here
-        [SerializeField] private GameObject _TargetShield;
+        [SerializeField] private GameObject _targetShield;
         
         public bool ShieldFits => _shieldFits;
         //Action so it doesn't need to constantly verify in update
@@ -19,7 +19,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
 
         private void OnTriggerEnter(Collider other)
         {
-            if (other.CompareTag(_shieldTag) && other.TryGetComponent(out Resizable resizable) && other.gameObject == _TargetShield)
+            if (other.CompareTag(_shieldTag) && other.TryGetComponent(out Resizable resizable) && other.gameObject == _targetShield)
             {
                 bool previousState = _shieldFits;
 

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -1,0 +1,49 @@
+using System;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Earth;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
+{
+    public class ShieldChecker : MonoBehaviour
+    {
+        [SerializeField] private string _shieldTag = "Shield";
+        [SerializeField] private bool _checkForShrunk;
+        [SerializeField] private bool _checkForGrown;
+        [SerializeField] private bool _shieldFits;
+        //Each shield is different so you should add the correct shield here
+        [SerializeField] private GameObject _TargetShield;
+        
+        public bool ShieldFits => _shieldFits;
+        //Action so it doesn't need to constantly verify in update
+        public event Action onShieldFitChanged;
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.CompareTag(_shieldTag) && other.TryGetComponent(out Resizable resizable) && other.gameObject == _TargetShield)
+            {
+                bool previousState = _shieldFits;
+
+                switch ((resizable.Shrunk, resizable.Grown))
+                {
+                    case (true, false):
+                        Debug.Log("Shield is shrunk");
+                        _shieldFits = true;
+                        break;
+                    case (false, true):
+                        Debug.Log("Shield is grown");
+                        _shieldFits = true;
+                        break;
+                    case (false, false):
+                        Debug.Log("Shield is regular size");
+                        _shieldFits = true;
+                        break;
+                }
+
+                if (previousState != _shieldFits)
+                {
+                    onShieldFitChanged?.Invoke();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -27,15 +27,18 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
                 {
                     case (true, false):
                         Debug.Log("Shield is shrunk");
-                        _shieldFits = true;
+                        _shieldFits = _checkForShrunk;
                         break;
                     case (false, true):
                         Debug.Log("Shield is grown");
-                        _shieldFits = true;
+                        _shieldFits = _checkForGrown;
                         break;
                     case (false, false):
                         Debug.Log("Shield is regular size");
-                        _shieldFits = true;
+                        _shieldFits = !_checkForShrunk && !_checkForGrown;
+                        break;
+                    default:
+                        _shieldFits = false;
                         break;
                 }
 

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs.meta
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65ac9b04478b2524bbeb577f33a8bd51

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
@@ -37,13 +37,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
             }
 
             if (_allShieldsFit)
-            {
                 Debug.Log("All shields fit");
-            }
             else
-            {
                 Debug.Log("Not all shields fit");
-            }
         }
     }
 }

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
+{
+    public class ShieldSequenceChecker : MonoBehaviour
+    {
+        [SerializeField] private List<ShieldChecker> _shieldCheckers;
+        [SerializeField] private bool _allShieldsFit;
+
+        private void OnEnable()
+        {
+            foreach (var shieldChecker in _shieldCheckers)
+            {
+                shieldChecker.onShieldFitChanged += CheckAllShields;
+            }
+        }
+
+        private void OnDisable()
+        {
+            foreach (var shieldChecker in _shieldCheckers)
+            {
+                shieldChecker.onShieldFitChanged -= CheckAllShields;
+            }
+        }
+
+        private void CheckAllShields()
+        {
+
+            foreach (var shieldChecker in _shieldCheckers)
+            {
+                if (!shieldChecker.ShieldFits)
+                {
+                    _allShieldsFit = false;
+                    break;
+                }
+            }
+
+            if (_allShieldsFit)
+            {
+                Debug.Log("All shields fit");
+            }
+            else
+            {
+                Debug.Log("Not all shields fit");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
@@ -14,6 +14,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
             {
                 shieldChecker.onShieldFitChanged += CheckAllShields;
             }
+            //Do an initial check
+            CheckAllShields();
         }
 
         private void OnDisable()
@@ -26,6 +28,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
 
         private void CheckAllShields()
         {
+            //It's true by default when checked initially (will be set false in the foreach, so no need to worry about early puzzle clears)
+            _allShieldsFit = true;
 
             foreach (var shieldChecker in _shieldCheckers)
             {

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs
@@ -6,7 +6,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
     public class ShieldSequenceChecker : MonoBehaviour
     {
         [SerializeField] private List<ShieldChecker> _shieldCheckers;
-        [SerializeField] private bool _allShieldsFit;
+        [SerializeField] private bool _allShieldsFit = true;
 
         private void OnEnable()
         {
@@ -28,9 +28,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
 
         private void CheckAllShields()
         {
-            //It's true by default when checked initially (will be set false in the foreach, so no need to worry about early puzzle clears)
-            _allShieldsFit = true;
-
             foreach (var shieldChecker in _shieldCheckers)
             {
                 if (!shieldChecker.ShieldFits)

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs.meta
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldSequenceChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f32bcae37f8ac9d48a2409d0a0ecfb9a


### PR DESCRIPTION
## Content

2 puzzles have been added to the earth room. The gate you can open, and the shield puzzle.

## Changes
### Added
`EarthGateChecker.cs` : Was created
`ShieldChecker.cs` : Was created
`ShieldSequenceChecker.cs` : Was created

### Updated
`Resizable.cs` : Was updated to have an event trigger and make grown/ shrunk accessible by other classes.

## Testing

The feature / Bugfix can be testing by following these steps:
**Gate puzzle**
1. Open the puzzle demo level
2. put the resizable on the chain blocks and set them accordingly
3. Set the 'EarthGateChecker' where you want, like on the gate
4. Put in a spell and name it "Grow" or just "Debug" and set it to isgrowspell active
5. Press play and a debug log should show up saying "Open the gate" when both blocks are grown
![GateChecker](https://github.com/user-attachments/assets/3a844b1d-0a2f-40e3-a49f-d7517b1c932f)


**Shield puzzle**
1. Add an empty parent and give it 'ShieldSequenceChecker'
2. Give it children with a trigger hitbox and these should have 'ShieldChecker'
3. Grab objects with collision, give them resizable script,  set them as target object and check for the correct sizes you want (Make sure these have rigidbodies, as that's necessary to check for collision)
4. Either let them fall in it, or drag them via the editor. They should disappear when its the correct object with the correct size
5. If you did everything right in the 'ShieldSequenceChecker' it should say that all shields fit
![shieldchecker](https://github.com/user-attachments/assets/21c4f764-ea02-4922-8529-807a872d1650)


Closes #25 
