### PR TITLE
✨ interactables resizable adjustments

### DIFF
--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -5,8 +5,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
 	internal class Resizable : EarthInteractable
 	{
-		[SerializeField] private Vector3 _initialSize;
 		[SerializeField] private Vector3 _shrinkSize;
+		[SerializeField] private Vector3  _defaultSize;
 		[SerializeField] private Vector3 _growSize;
 
 		[SerializeField] private Transform _targetObject;
@@ -22,14 +22,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 		internal override void Awake()
 		{
 			//Sorry, but this was necessary for now, if you have something better, feel free to say so :)
-
 			base.Awake();
-			_initialSize = _targetObject.localScale;
-
+			
 			if (_shrunk)
 				_targetObject.localScale = _shrinkSize;
 			else if (_grown)
 				_targetObject.localScale = _growSize;
+			else
+				_targetObject.localScale = _defaultSize;
 		}
 
 		internal override void Touched()
@@ -50,7 +50,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 		{
 			if (_shrunk)
 			{
-				_targetObject.localScale = _initialSize;
+				_targetObject.localScale = _defaultSize;
 				_shrunk = false;
 			}
 			else
@@ -67,7 +67,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 		{
 			if (_grown)
 			{
-				_targetObject.localScale = _initialSize;
+				_targetObject.localScale = _defaultSize;
 				_grown = false;
 			}
 

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -3,82 +3,58 @@ using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 {
-	internal class Resizable : EarthInteractable
-	{
-		[SerializeField] private Vector3 _shrinkSize;
-		[SerializeField] private Vector3  _defaultSize;
-		[SerializeField] private Vector3 _growSize;
+    internal class Resizable : EarthInteractable
+    {
+        [SerializeField] private Vector3 _shrinkSize;
+        [SerializeField] private Vector3 _defaultSize;
+        [SerializeField] private Vector3 _growSize;
 
-		[SerializeField] private Transform _targetObject;
+        [SerializeField] private Transform _targetObject;
 
-		[SerializeField] private bool _shrunk;
-		[SerializeField] private bool _grown;
+        [SerializeField] private ResizeState _currentState = ResizeState.Default;
 
-		internal event Action onSizeChanged;
-		
-		public bool Shrunk => _shrunk;
-        public bool Grown => _grown;
-        
-		internal override void Awake()
-		{
-			//Sorry, but this was necessary for now, if you have something better, feel free to say so :)
-			base.Awake();
-			
-			if (_shrunk)
-				_targetObject.localScale = _shrinkSize;
-			else if (_grown)
-				_targetObject.localScale = _growSize;
-			else
-				_targetObject.localScale = _defaultSize;
-		}
+        internal event Action onSizeChanged;
 
-		internal override void Touched()
-		{
-			ResizeObject();
-		}
+        public ResizeState CurrentState => _currentState;
 
-		private void ResizeObject()
-		{
-			if (_isGrowSpellActive && !_grown)
-				GrowObject();
+        internal override void Awake()
+        {
+            base.Awake();
+            SetObjectScale();
+        }
 
-			else if (_isShrinkSpellActive && !_shrunk)
-				ShrinkObject();
-		}
+        internal override void Touched()
+        {
+            ResizeObject();
+        }
 
-		private void GrowObject()
-		{
-			if (_shrunk)
-			{
-				_targetObject.localScale = _defaultSize;
-				_shrunk = false;
-			}
-			else
-			{
-				_targetObject.localScale = _growSize;
-				_grown = true;
-			}
+        private void ResizeObject()
+        {
+            if (_currentState == ResizeState.Shrunk)
+            {
+                ChangeState(ResizeState.Default, _defaultSize);
+            }
+            else if (_currentState == ResizeState.Default)
+            {
+                ChangeState(ResizeState.Grown, _growSize);
+            }
+        }
 
-			_isGrowSpellActive = false;
+        private void ChangeState(ResizeState newState, Vector3 newSize)
+        {
+            _targetObject.localScale = newSize;
+            _currentState = newState;
             onSizeChanged?.Invoke();
-		}
+        }
 
-		private void ShrinkObject()
-		{
-			if (_grown)
-			{
-				_targetObject.localScale = _defaultSize;
-				_grown = false;
-			}
-
-			else
-			{
-				_targetObject.localScale = _shrinkSize;
-				_shrunk = true;
-			}
-
-			_isShrinkSpellActive = false;
-            onSizeChanged?.Invoke();
-		}
-	}
+        private void SetObjectScale()
+        {
+            _targetObject.localScale = _currentState switch
+            {
+                ResizeState.Shrunk => _shrinkSize,
+                ResizeState.Grown => _growSize,
+                _ => _defaultSize,
+            };
+        }
+    }
 }

--- a/Assets/Scripts/Interactables/Earth/Resizable.cs
+++ b/Assets/Scripts/Interactables/Earth/Resizable.cs
@@ -25,19 +25,34 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
 
         internal override void Touched()
         {
-            ResizeObject();
-        }
+            if (_isGrowSpellActive)
+            {
+                switch (_currentState)
+                {
+                    case ResizeState.Default:
+                        ChangeState(ResizeState.Grown, _growSize);
+                        break;
 
-        private void ResizeObject()
-        {
-            if (_currentState == ResizeState.Shrunk)
-            {
-                ChangeState(ResizeState.Default, _defaultSize);
+                    case ResizeState.Shrunk:
+                        ChangeState(ResizeState.Default, _defaultSize);
+                        break;
+
+                }
             }
-            else if (_currentState == ResizeState.Default)
+            else if (_isShrinkSpellActive)
             {
-                ChangeState(ResizeState.Grown, _growSize);
+                switch (_currentState)
+                {
+                    case ResizeState.Default:
+                        ChangeState(ResizeState.Shrunk, _shrinkSize);
+                        break;
+
+                    case ResizeState.Grown:
+                        ChangeState(ResizeState.Default, _defaultSize);
+                        break;
+                }
             }
+               
         }
 
         private void ChangeState(ResizeState newState, Vector3 newSize)
@@ -45,6 +60,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
             _targetObject.localScale = newSize;
             _currentState = newState;
             onSizeChanged?.Invoke();
+
+            _isGrowSpellActive = false;
+            _isShrinkSpellActive = false;
         }
 
         private void SetObjectScale()

--- a/Assets/Scripts/Interactables/Earth/ResizeState.cs
+++ b/Assets/Scripts/Interactables/Earth/ResizeState.cs
@@ -1,0 +1,9 @@
+namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Earth
+{
+	internal enum ResizeState
+	{
+        Shrunk,
+		Default,
+        Grown
+	}
+}

--- a/Assets/Scripts/Interactables/Earth/ResizeState.cs.meta
+++ b/Assets/Scripts/Interactables/Earth/ResizeState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16736db8050af7444b8395723039dd90

--- a/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
@@ -28,22 +28,21 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
 
         private void CheckGateStatus()
         {
-            if (AreAllBlocksGrown())
-                //Later implementation of Loes' animation
+            if (AreAllBlocksInState(ResizeState.Grown))
+               //Later implementation of Loes' animation 
                 Debug.Log("Open the gate");
         }
 
-        private bool AreAllBlocksGrown()
+        private bool AreAllBlocksInState(ResizeState requiredState)
         {
             foreach (var resizable in _resizableBlocks)
             {
-                if (resizable == null || !resizable.Grown)
+                if (resizable == null || resizable.CurrentState != requiredState)
                 {
-                    Debug.Log("Not all are grown");
+                    Debug.Log("Not all blocks are in the required state: " + requiredState);
                     return false;
                 }
             }
-
             return true;
         }
     }

--- a/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/ShieldChecker.cs
@@ -13,9 +13,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
         //Each shield is different so you should add the correct shield here
         [SerializeField] private GameObject _targetShield;
         [SerializeField] private Resizable _targetResizable;
-        
+
         public bool ShieldFits => _shieldFits;
         //Action so it doesn't need to constantly verify in update
+
         public event Action onShieldFitChanged;
 
         private void OnTriggerEnter(Collider other)
@@ -23,37 +24,39 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
             if (other.CompareTag(_shieldTag) && other.gameObject == _targetShield)
             {
                 bool previousState = _shieldFits;
-
-                switch ((_targetResizable.Shrunk, _targetResizable.Grown))
-                {
-                    case (true, false):
-                        Debug.Log("Shield is shrunk");
-                        _shieldFits = _checkForShrunk;
-                        break;
-                    case (false, true):
-                        Debug.Log("Shield is grown");
-                        _shieldFits = _checkForGrown;
-                        break;
-                    case (false, false):
-                        Debug.Log("Shield is regular size");
-                        _shieldFits = !_checkForShrunk && !_checkForGrown;
-                        break;
-                    default:
-                        _shieldFits = false;
-                        break;
-                }
+                _shieldFits = IsShieldInRequiredState();
 
                 if (previousState != _shieldFits)
+                {
                     onShieldFitChanged?.Invoke();
-                
+                }
+
                 if (_shieldFits)
                     //Just disable for now, could have an extra statement checking if the user still has it grabbed
+                {
                     _targetShield.SetActive(false);
+                    Debug.Log("Shield fits and is disabled");
+                }
                 else
                 {
                     //Placeholder debug log as requested
                     Debug.Log("Shield doesn't fit");
                 }
+            }
+        }
+
+        private bool IsShieldInRequiredState()
+        {
+            switch (_targetResizable.CurrentState)
+            {
+                case ResizeState.Shrunk:
+                    return _checkForShrunk;
+                case ResizeState.Grown:
+                    return _checkForGrown;
+                case ResizeState.Default:
+                    return !_checkForShrunk && !_checkForGrown;
+                default:
+                    return false;
             }
         }
     }


### PR DESCRIPTION
## Content

The enum was created instead of the booleans and the classes using the booleans have been adjusted to use said enum

## Changes

### Added
`ResizeState` : Was created

### Updated
`Resizable.cs` : Was updated
`ShieldChecker.cs` : Was updated
`EarthGateChecker.cs` : Was updated

## Testing

The feature / Bugfix can be testing by following these steps:

#112 
Basically the same testing method as the previous pull request, except instead of setting the object to grown/shrunk via a boolean, you can simply use the resizestate in the editor to choose between "Shrunk, Default, Grown"

