### PR TITLE
✨ door puzzle prototype

### DIFF
--- a/Assets/Scripts/Puzzle/MainRoom.meta
+++ b/Assets/Scripts/Puzzle/MainRoom.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef79d7403e57dbc498a49e7aa0c7d29a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace RogueApeStudios.SecretsOfIgnacios
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 {
     public class DragonDoorPuzzle : MonoBehaviour
     {

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios
+{
+    public class DragonDoorPuzzle : MonoBehaviour
+    {
+        [SerializeField] private Animator _animator;
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.gameObject.CompareTag("Potion"))
+            {
+                other.gameObject.SetActive(false);
+                gameObject.SetActive(false);
+                _animator.SetTrigger("DoorOpen");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs.meta
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a47e6770096e02c4b80484b20dd19375

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
@@ -1,0 +1,42 @@
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Wind;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios
+{
+    public class ElementDoorPuzzle : MonoBehaviour
+    {
+        [SerializeField] private List<Interactables.Interactables> _targets;
+
+        [SerializeField] private Fillable _waterTarget;
+        [SerializeField] private Blowable _windTarget;
+        [SerializeField] private PersistentFire _fireTarget;
+
+        [SerializeField] private Animator _animator;
+
+        private void Awake()
+        {
+            _waterTarget.onFilled += TargetCheck;
+            _windTarget.onBlown += TargetCheck;
+            _fireTarget.OnIgnitionToggle += TargetCheck;
+        }
+
+        private void OnDestroy()
+        {
+            _waterTarget.onFilled -= TargetCheck;
+            _windTarget.onBlown -= TargetCheck;
+            _fireTarget.OnIgnitionToggle -= TargetCheck;
+        }
+
+        private void TargetCheck(bool hit)
+        {
+            if (_waterTarget._filled && _windTarget._isBlown && _fireTarget._isOnFire)
+            {
+                Debug.Log("Door opens");
+                _animator.SetTrigger("DoorOpen");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
@@ -4,7 +4,7 @@ using RogueApeStudios.SecretsOfIgnacios.Interactables.Wind;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace RogueApeStudios.SecretsOfIgnacios
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 {
     public class ElementDoorPuzzle : MonoBehaviour
     {

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs.meta
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65d03a9ec637bf24db804218c0a1d653

--- a/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios
+{
+    public class PotionPuzzle : MonoBehaviour
+    {
+        [SerializeField] private GameObject _containedObject;
+        private float _count;
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.gameObject.CompareTag("Ingredient"))
+            {
+                _count++;
+                other.gameObject.SetActive(false);
+            }
+            else if (!other.gameObject.CompareTag("Ingredient") && !other.gameObject.CompareTag("Player"))
+            {
+                Debug.Log("Wrong!");
+                if (other.TryGetComponent<Rigidbody>(out Rigidbody rb))
+                {
+                    // Successfully found the Rigidbody component
+                    rb.AddForce(Vector3.up * 10, ForceMode.Impulse);
+                    Debug.Log(rb);
+                }
+            }
+            PotionCheck();
+        }
+
+        private void PotionCheck()
+        {
+            if (_count == 3)
+            {
+                _containedObject.SetActive(true);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace RogueApeStudios.SecretsOfIgnacios
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 {
     public class PotionPuzzle : MonoBehaviour
     {

--- a/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs.meta
+++ b/Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee3ddecc462ecf945bf90387c172c4d1

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,6 +9,8 @@ TagManager:
   - UIButtonTab
   - UIButtonBracelet
   - WindSpell
+  - Ingredient
+  - Potion
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Content

Added the puzzle prototypes for the two doors that lead to the wind and earth rooms.

## Changes
### Added
`Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs` : Was created. 
`Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs` : Was created. 
`Assets/Scripts/Puzzle/MainRoom/PotionPuzzle.cs` : Was created. 

### Updated
`ProjectSettings/TagManager.asset` : Was updated. Added more tags.

## Testing

The feature can be testing by following these steps:

1. Place correct scripts on the doors
2. Play the game
3. Look with your eyes