### PR TITLE
🐛 No cast spell activation

### DIFF
--- a/Assets/Scripts/Puzzle/General/Spells/ProjectileSpellLogic.cs
+++ b/Assets/Scripts/Puzzle/General/Spells/ProjectileSpellLogic.cs
@@ -98,7 +98,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.General.Spells
         {
             await UniTask.WaitForSeconds(time, cancellationToken: token);
 
-            if (!_collided)
+            if (!_collided && gameObject.activeSelf)
                 _objectPooler.ReturnProjectile(_pool.ToString(), gameObject);
         }
 

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -83,10 +83,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             switch (_spellManager.CurrentSpell._castType)
             {
                 case CastTypes.SingleFire:
-                    _pooler.GetProjectile(_spellManager.CurrentSpell._elementType.ToString(),
-                    _spellManager.CurrentSpell._spellPrefab,
-                    handData._handTransform);
-                    handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
+                    SingleCast(handData);
                     break;
                 case CastTypes.Automatic:
                     RepeatedCast(handData);
@@ -94,6 +91,15 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 default:
                     throw new NotImplementedException("Cast type not implemented.");
             }
+        }
+
+        private void SingleCast(HandData handData)
+        {
+            _pooler.GetProjectile(_spellManager.CurrentSpell._elementType.ToString(),
+                    _spellManager.CurrentSpell._spellPrefab,
+                    handData._handTransform);
+            handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
+            handData._canCast = false;
         }
 
         private async void RepeatedCast(HandData handData)


### PR DESCRIPTION
## Content

Fix the bug where a player could cast single fire spells multiple times without doing the sequence or quick cast beforehand. Also removed null errors.

## Changes

### Updated
`Assets/Scripts/Puzzle/General/Spells/ProjectileSpellLogic.cs` : Was updated / renamed. No more null exceptions when you start the game.
`Assets/Scripts/Spells/Cast.cs` : Was updated / renamed. Set can cast to false after casting.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Cast single fire spell.
2. Try doing it again without using the sequence or quick cast. (Spoiler you can't)

Closes #135 
