### PR TITLE
✨ stop hand vfx after cast

### DIFF
--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -4,12 +4,16 @@ using RogueApeStudios.SecretsOfIgnacios.Gestures;
 using Cysharp.Threading.Tasks;
 using System.Threading;
 using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using RogueApeStudios.SecretsOfIgnacios.Gestures;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
+using UnityEngine;
 using UnityEngine.VFX;
 using NUnit.Framework.Internal;
 using UnityEngine.XR.Hands;
 
-
-namespace RogueApeStudios.SecretsOfIgnacios
+namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 {
     public class HandVfxManager : MonoBehaviour
     {
@@ -50,6 +54,8 @@ namespace RogueApeStudios.SecretsOfIgnacios
             //unsubscribe
             SpellManager.OnSpellValidation -= HandleCastRecognized;
             _sequenceManager.OnGestureRecognised -= HandleElementRecognized;
+            
+            _castscript.onSpellCastComplete -= DisableHandVFX;
             //unsubscribe from cast script's cast finished event (event on cast not implemented)
         }
 
@@ -58,6 +64,8 @@ namespace RogueApeStudios.SecretsOfIgnacios
             //subscribe!
             SpellManager.OnSpellValidation += HandleCastRecognized;
             _sequenceManager.OnGestureRecognised += HandleElementRecognized;
+            
+            _castscript.onSpellCastComplete += DisableHandVFX;
             //subscribe to cast script's cast finished event (event on cast not implemented)
         }
 

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -39,7 +39,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
         private void OnDestroy()
         {
-            SpellManager.OnSpellValidation += HandleSpellValidation;
+            SpellManager.OnSpellValidation -= HandleSpellValidation;
 
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.VFX;
+using UnityEngine.XR.Hands;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Spells
 {
@@ -19,6 +20,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [SerializeField] private bool _timerAim = true;
         [SerializeField] private float _castTimer = 0.75f;
 
+        internal event Action<Handedness> onSpellCastComplete;
+        
         private CancellationTokenSource _cancellationTokenSource;
 
         private void Awake()
@@ -100,6 +103,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                     handData._handTransform);
             handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
             handData._canCast = false;
+            
+            RemoveVFXFromHand(handData);
         }
 
         private async void RepeatedCast(HandData handData)
@@ -124,9 +129,22 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 handData._isCasting = false;
                 handData._canCast = false;
                 handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
+                
+                RemoveVFXFromHand(handData);
             }
         }
 
+        private void RemoveVFXFromHand(HandData handData)
+        {
+            if (handData == null) return;
+            
+            Handedness handIdentifier = handData == _leftHandData ? Handedness.Left : Handedness.Right;
+
+            Debug.Log("invoking");
+            onSpellCastComplete?.Invoke(handIdentifier);
+        }
+        
+        
         private void HandleSpellValidation(bool canCast)
         {
             _rightHandData._canCast = canCast;


### PR DESCRIPTION
## Content

This is 1/2 of the task. This is the part where it simply removes the effect from your hand after a successful cast.

## Changes
### Updated
`Cast.cs` : Was updated to now send events so the hands can be turned off (now also unsubscribes)
`HandVfxManager.cs` : Was updated to use said event to remove the effect from the hands


## Testing

1. Put playerrig into scene
2. Add the handvfx manager
3. Cast fire spell
4. Watch the effect disappear

https://i.imgur.com/Ab1yr2G.gif