### PR TITLE
🐛 Wrong element on hands

### DIFF
--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit.AR;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 {
@@ -31,6 +32,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         internal event Action OnReset;
         internal event Action OnQuickCast;
         internal event Action<Gesture> OnGestureRecognised;
+        internal event Action<Gesture> OnElementValidated; 
 
         internal List<Gesture> ValidatedGestures => _validatedGestures;
 
@@ -79,6 +81,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                     OnReset?.Invoke();
                     _sequenceStarted = true;
                     _canQuickCast = false;
+                    
+                    OnElementValidated?.Invoke(_currentGesture);
                 }
                 else if (_canQuickCast && _currentGesture._name == "Quick Cast" && _leftHandActive &&
                     _rightHandActive && _currentGesture._leftHandShape == HandShape.QuickCast &&
@@ -86,6 +90,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                 {
                     _validatedGestures.Clear();
                     OnQuickCast?.Invoke();
+                    
+                    OnElementValidated?.Invoke(_currentGesture);
                 }
 
                 if (_sequenceStarted && _validatedGestures.Count == 0 ||
@@ -97,6 +103,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                     OnGestureRecognised?.Invoke(_currentGesture);
                 }
 
+                if (_validatedGestures.Count == 2)
+                {
+                    OnElementValidated?.Invoke(_currentGesture);
+                }
+                
                 if (_validatedGestures.Count == 3)
                 {
                     OnSequenceCreated?.Invoke();

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -32,7 +32,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         internal event Action OnReset;
         internal event Action OnQuickCast;
         internal event Action<Gesture> OnGestureRecognised;
-        internal event Action<Gesture> OnElementValidated; 
+        internal event Action<Gesture> OnElementValidated;
+        internal event Action OnSpellFailedVFX;
 
         internal List<Gesture> ValidatedGestures => _validatedGestures;
 
@@ -40,17 +41,22 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         {
             _cancellationTokenSource = new CancellationTokenSource();
             SpellManager.OnSpellValidation += HandleOnSpellValidated;
+            SpellManager.OnSpellFailed += HandleOnSpellFailed;
+            
             _defaultColor = _rightHandMaterial.materials[1].GetColor("_MainColor");
         }
 
         private void OnDestroy()
         {
+            SpellManager.OnSpellFailed -= HandleOnSpellFailed;
+            SpellManager.OnSpellValidation -= HandleOnSpellValidated;
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
         }
 
         private void FixedUpdate()
         {
+            Debug.Log(_validatedGestures.Count);
             if (_leftHandActive && _rightHandActive && !_gestureValidated && _currentGesture != null)
                 HandDistanceCheck(_currentGesture);
         }
@@ -168,6 +174,13 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         {
             _canQuickCast = value;
         }
+
+       private void HandleOnSpellFailed()
+       {
+           _validatedGestures.Clear(); 
+           _sequenceStarted = false; 
+           OnSpellFailedVFX?.Invoke(); // Invoke the event to disable VFX on hands
+       }
 
         public void SetRightHandShape(string handShape)
         {

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -53,7 +53,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             _cancellationTokenSource.Dispose();
             //unsubscribe
             SpellManager.OnSpellValidation -= HandleCastRecognized;
-            _sequenceManager.OnGestureRecognised -= HandleElementRecognized;
+
+            _sequenceManager.OnElementValidated -= HandleElementRecognized;
             
             _castscript.onSpellCastComplete -= DisableHandVFX;
             //unsubscribe from cast script's cast finished event (event on cast not implemented)
@@ -63,8 +64,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
         {
             //subscribe!
             SpellManager.OnSpellValidation += HandleCastRecognized;
-            _sequenceManager.OnGestureRecognised += HandleElementRecognized;
-            
+            _sequenceManager.OnElementValidated += HandleElementRecognized;
             _castscript.onSpellCastComplete += DisableHandVFX;
             //subscribe to cast script's cast finished event (event on cast not implemented)
         }

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -53,17 +53,30 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             _cancellationTokenSource.Dispose();
             //unsubscribe
             SpellManager.OnSpellValidation -= HandleCastRecognized;
-
+            SpellManager.OnSpellFailed -= SpellManagerOnOnSpellFailed;
             _sequenceManager.OnElementValidated -= HandleElementRecognized;
             
             _castscript.onSpellCastComplete -= DisableHandVFX;
             //unsubscribe from cast script's cast finished event (event on cast not implemented)
         }
 
+        private void SpellManagerOnOnSpellFailed()
+        { 
+            if(_currentEffectL != null) 
+            { 
+                _currentEffectL.Stop();
+            }
+            if(_currentEffectR != null) 
+            {
+                _currentEffectR.Stop();
+            }
+        }
+
         void Start()
         {
             //subscribe!
             SpellManager.OnSpellValidation += HandleCastRecognized;
+            SpellManager.OnSpellFailed += SpellManagerOnOnSpellFailed;
             _sequenceManager.OnElementValidated += HandleElementRecognized;
             _castscript.onSpellCastComplete += DisableHandVFX;
             //subscribe to cast script's cast finished event (event on cast not implemented)

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
@@ -26,6 +26,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
             //sub to the gesture recognized and spell recognized events
             _magicCircle.Stop();
             SpellManager.OnSpellValidation += HandleSpellRecognized;
+            SpellManager.OnSpellFailed += HandleSpellFailed;
             _sequenceManager.OnGestureRecognised += HandleGestureRecognized;
         }
         private void OnDestroy()
@@ -59,6 +60,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
         }
 
         void HandleSpellRecognized(bool recognized)
+        {
+            _boolControls.SetActive(false);
+        }
+
+        private void HandleSpellFailed()
         {
             _boolControls.SetActive(false);
         }

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -26,6 +26,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private Color _defaultColor;
 
         public static event Action<bool> OnSpellValidation;
+        public static event Action OnSpellFailed;
 
         internal Spell CurrentSpell => _currentSpell;
         internal Color DefaultColor => _defaultColor;
@@ -72,6 +73,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             if (!spellFound)
             {
                 _currentSpell = null;
+                OnSpellFailed?.Invoke();
                 SpellWrongIndication(_cancellationTokenSource.Token);
             }
             else

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -74,8 +74,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 _currentSpell = null;
                 SpellWrongIndication(_cancellationTokenSource.Token);
             }
-
-            OnSpellValidation?.Invoke(spellFound);
+            else
+                OnSpellValidation?.Invoke(spellFound);
         }
 
         private void SetSpell(Spell spell)


### PR DESCRIPTION
## Content

The player now has the correct element on their hands when casting a spell

## Changes
### Updated
`Assets/Scripts/Gestures/SequenceManager.cs` : Was updated to fire another event
`Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs` : Was updated to use said new event to change element vfx

## Testing

The feature / Bugfix can be testing by following these steps:

1. Open the scene
2. Drag in player
3. Cast fire spell
4. Cast wind spell
5. See it change 

