### PR TITLE
:bug: water-resizable-pots-puzzle

### DIFF
--- a/Assets/Scripts/Puzzle/WaterRoom/GatePuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/WaterRoom/GatePuzzleCheck.cs
@@ -1,22 +1,26 @@
-using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
 using System.Collections.Generic;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
+using RogueApeStudios.SecretsOfIgnacios.Interactables.Earth;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
 {
     public class GatePuzzleCheck : MonoBehaviour
     {
         [SerializeField] private List<Fillable> _vases;
+        [SerializeField] private List<Resizable> _resizableVases;
         [SerializeField] private Animator _animator;
 
         private void Awake()
         {
-
             foreach (var vase in _vases)
             {
                 vase.onFilled += VaseCheck;
-                
+            }
+
+            foreach (var vase in _resizableVases)
+            {
+                vase.onSizeChanged += VaseCheck;
             }
         }
 
@@ -26,14 +30,31 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
             {
                 vase.onFilled -= VaseCheck;
             }
+
+            foreach (var vase in _resizableVases)
+            {
+                vase.onSizeChanged -= VaseCheck;
+            }
         }
 
+        //This is literally only because the event is a bool...... it's not even used.
         private void VaseCheck(bool filled)
         {
+            CheckVaseConditions();
+        }
+
+        private void VaseCheck()
+        {
+            CheckVaseConditions();
+        }
+
+        private void CheckVaseConditions()
+        {
             int count = 0;
+
             foreach (var vase in _vases)
             {
-                if (vase._filled /*&& if vase state is default*/)
+                if (vase._filled && IsVaseGrown(vase))
                 {
                     count++;
                 }
@@ -44,6 +65,19 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
                 Debug.Log("Gate opens");
                 _animator.SetTrigger("GateOpen");
             }
+        }
+        
+        private bool IsVaseGrown(Fillable vase)
+        {
+            foreach (var resizable in _resizableVases)
+            {
+                if (vase.gameObject == resizable.gameObject && resizable.CurrentState == ResizeState.Grown)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Content
Vases have to be filled and grown now

## Changes
### Updated
`Assets/Scripts/Puzzle/WaterRoom/GatePuzzleCheck.cs` : Was updated

## Testing

The feature / Bugfix can be testing by following these steps:

1. add 2 objects into scene
2. give them resizable, fillable and 2 spell receivers each
3. add an object to be the gate
4. put the gatepuzzlecheck on it
5. add both objects into both lists
6. fill and grow the vases and it should say gate opens


