### PR TITLE
🐛Fix Wind Projectile

### DIFF
--- a/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
@@ -132,7 +132,7 @@ GameObject:
   - component: {fileID: -2397331427679202286}
   m_Layer: 9
   m_Name: Wind Spell Ranged
-  m_TagString: Spell
+  m_TagString: WindSpell
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
@@ -132,7 +132,7 @@ GameObject:
   - component: {fileID: -2397331427679202286}
   m_Layer: 9
   m_Name: Wind Spell Ranged
-  m_TagString: WindSpell
+  m_TagString: Spell
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/SpellReceiver/SpellReceiver.prefab
+++ b/Assets/Prefabs/SpellReceiver/SpellReceiver.prefab
@@ -45,6 +45,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4d36b8b857aff74d8250803d7439b4c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _spellTags:
+  - Spell
+  - WindSpell
 --- !u!65 &4936965792756282574
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Puzzle/General/SpellReceiver.cs
+++ b/Assets/Scripts/Puzzle/General/SpellReceiver.cs
@@ -1,15 +1,17 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle
 {
     public class SpellReceiver : MonoBehaviour
     {
+        [SerializeField] private List<string> _spellTags;
         internal event Action<string> OnSpellReceived;
 
         private void OnTriggerEnter(Collider other)
         {
-            if (other.gameObject.CompareTag("Spell"))
+            if (_spellTags.Contains(other.tag))
             {
                 var spell = other.gameObject;
                 HandleSpellReceived(spell);


### PR DESCRIPTION
Thanks tim

## Content
Spell receiver now takes a list of tags

## Changes
### Updated
`Assets/Scripts/Puzzle/General/SpellReceiver.cs` : Changed to have a list of tags
`Assets/Prefabs/SpellReceiver/SpellReceiver.prefab`: Changed to have both spells in the list

## Testing

The feature / Bugfix can be testing by following these steps:

1. go to wind room
2. cast wind spell on fan and pipe
3. profit
