### PR TITLE
🐛  Grimoire spell collision

### DIFF
--- a/Assets/Prefabs/Grimiore/Bookholder.prefab
+++ b/Assets/Prefabs/Grimiore/Bookholder.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 34211194418823677}
   - component: {fileID: 3129930213364717907}
   - component: {fileID: 7475773504636264327}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -137,7 +137,7 @@ GameObject:
   - component: {fileID: 7121516907244104189}
   - component: {fileID: 4144848356713284247}
   - component: {fileID: 8826267297725057828}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -273,7 +273,7 @@ GameObject:
   - component: {fileID: 383855470886981988}
   - component: {fileID: 4548791160860018010}
   - component: {fileID: 5539571354065923586}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -347,7 +347,7 @@ GameObject:
   - component: {fileID: 580342560742712543}
   - component: {fileID: 2290216760342130896}
   - component: {fileID: 2804111530190107484}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: WaterTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -458,7 +458,7 @@ GameObject:
   - component: {fileID: 3579348526119966096}
   - component: {fileID: 3551248203653438989}
   - component: {fileID: 6542333633962789210}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -594,7 +594,7 @@ GameObject:
   - component: {fileID: 1773055570390342706}
   - component: {fileID: 3142471517501215018}
   - component: {fileID: 6083955320608857810}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -664,7 +664,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 262562124162450641}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: TeleportChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -701,7 +701,7 @@ GameObject:
   - component: {fileID: 8375984048762975849}
   - component: {fileID: 8828327533784488787}
   - component: {fileID: 823100310445423589}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -822,7 +822,7 @@ GameObject:
   - component: {fileID: 1087915316368421520}
   - component: {fileID: 8819863850890264913}
   - component: {fileID: 1200295202396844695}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -958,7 +958,7 @@ GameObject:
   - component: {fileID: 2990950950831420755}
   - component: {fileID: 2472968517437770376}
   - component: {fileID: 57854063771660881}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1028,7 +1028,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7230347029620992220}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: EarthChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1063,7 +1063,7 @@ GameObject:
   - component: {fileID: 2815690264840808485}
   - component: {fileID: 7741124748952253780}
   - component: {fileID: 6511455787189321828}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1199,7 +1199,7 @@ GameObject:
   - component: {fileID: 8493091719629446761}
   - component: {fileID: 8965756290282212508}
   - component: {fileID: 8148699157773424296}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1273,7 +1273,7 @@ GameObject:
   - component: {fileID: 6503246250631617145}
   - component: {fileID: 8848293522095587808}
   - component: {fileID: 2854932805586378458}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1393,7 +1393,7 @@ GameObject:
   - component: {fileID: 5252517774690415834}
   - component: {fileID: 3152068493415925055}
   - component: {fileID: 4954149877747679094}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1469,7 +1469,7 @@ GameObject:
   - component: {fileID: 2615451506809124087}
   - component: {fileID: 5246896699210080303}
   - component: {fileID: 5961745488539738307}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1607,7 +1607,7 @@ GameObject:
   - component: {fileID: 8594432133459380599}
   - component: {fileID: 5781896679298456394}
   - component: {fileID: 4248309941647931002}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1731,7 +1731,7 @@ GameObject:
   - component: {fileID: 3276347728421409684}
   - component: {fileID: 4537317271754336062}
   - component: {fileID: 5380587700343267635}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1803,7 +1803,7 @@ GameObject:
   - component: {fileID: 4704475393086624706}
   - component: {fileID: 243244609260605814}
   - component: {fileID: 9007078552658046694}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1877,7 +1877,7 @@ GameObject:
   - component: {fileID: 1516320201206876949}
   - component: {fileID: 5669966306058847543}
   - component: {fileID: 4917292701891606489}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: TabsElemental
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1999,7 +1999,7 @@ GameObject:
   - component: {fileID: 3309611749529303242}
   - component: {fileID: 4548023473974479925}
   - component: {fileID: 1261847041202024608}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2122,7 +2122,7 @@ GameObject:
   - component: {fileID: 5965570608059976743}
   - component: {fileID: 6805010303543139471}
   - component: {fileID: 1655989201904261751}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: FireTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -2233,7 +2233,7 @@ GameObject:
   - component: {fileID: 2920966546282370192}
   - component: {fileID: 2755612113923533912}
   - component: {fileID: 5123740643330040784}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2369,7 +2369,7 @@ GameObject:
   - component: {fileID: 1585304611296463463}
   - component: {fileID: 3502853468991099882}
   - component: {fileID: 6409626311691511328}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2505,7 +2505,7 @@ GameObject:
   - component: {fileID: 4310412430176867925}
   - component: {fileID: 900283220951685616}
   - component: {fileID: 3141970578529922362}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Book
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2601,7 +2601,7 @@ GameObject:
   - component: {fileID: 7774039020620494480}
   - component: {fileID: 5214222645244911664}
   - component: {fileID: 6483744478883870297}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2673,7 +2673,7 @@ GameObject:
   - component: {fileID: 6567199788822006583}
   - component: {fileID: 3517746262530082516}
   - component: {fileID: 4969817943450449037}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2809,7 +2809,7 @@ GameObject:
   - component: {fileID: 3828566552295052254}
   - component: {fileID: 8340621457442660504}
   - component: {fileID: 5990798237438348568}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2945,7 +2945,7 @@ GameObject:
   - component: {fileID: 5323549873629391370}
   - component: {fileID: 4580935104974237461}
   - component: {fileID: 5068970315969407582}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3083,7 +3083,7 @@ GameObject:
   - component: {fileID: 2061340113373279084}
   - component: {fileID: 4759573218386493650}
   - component: {fileID: 3670886309992150343}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: TabsBase
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3203,7 +3203,7 @@ GameObject:
   - component: {fileID: 7226526582491186990}
   - component: {fileID: 4994777252014160090}
   - component: {fileID: 6079820422173279908}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3341,7 +3341,7 @@ GameObject:
   - component: {fileID: 8293252083978108149}
   - component: {fileID: 2777510341715238549}
   - component: {fileID: 5933299891102622139}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3461,7 +3461,7 @@ GameObject:
   - component: {fileID: 7804133732531871917}
   - component: {fileID: 5930810201757093773}
   - component: {fileID: 3126517801358750569}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3533,7 +3533,7 @@ GameObject:
   - component: {fileID: 5816494657164581358}
   - component: {fileID: 9201909056442499066}
   - component: {fileID: 7360771547549387898}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3607,7 +3607,7 @@ GameObject:
   - component: {fileID: 3105148346953647642}
   - component: {fileID: 3004246020322954364}
   - component: {fileID: 947414607193199544}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3728,7 +3728,7 @@ GameObject:
   - component: {fileID: 6615241418363767652}
   - component: {fileID: 5976586955948794228}
   - component: {fileID: 7282929209492783978}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3798,7 +3798,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 533202662400064790}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: StartChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3833,7 +3833,7 @@ GameObject:
   - component: {fileID: 69937771947423777}
   - component: {fileID: 5195841829625547624}
   - component: {fileID: 4650348312258690278}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3967,7 +3967,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5200131694015046639}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: AirChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4004,7 +4004,7 @@ GameObject:
   - component: {fileID: 7799079293725925481}
   - component: {fileID: 8196413189088468085}
   - component: {fileID: 4959446692194025126}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4128,7 +4128,7 @@ GameObject:
   - component: {fileID: 5430125761440471069}
   - component: {fileID: 3555545240929843408}
   - component: {fileID: 7659856108741488744}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4199,7 +4199,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8121273555303013067}
   - component: {fileID: 3919579633022511349}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Bookholder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4252,7 +4252,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7329933841830531608}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: WaterChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4287,7 +4287,7 @@ GameObject:
   - component: {fileID: 3761689467213527897}
   - component: {fileID: 892047476523961684}
   - component: {fileID: 3889479248581139665}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4425,7 +4425,7 @@ GameObject:
   - component: {fileID: 8117938009269602554}
   - component: {fileID: 2565729835749930963}
   - component: {fileID: 3228972125116645297}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4549,7 +4549,7 @@ GameObject:
   - component: {fileID: 8848427678945829311}
   - component: {fileID: 8780754108270303907}
   - component: {fileID: 7934830799581899767}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4685,7 +4685,7 @@ GameObject:
   - component: {fileID: 5911653885511497668}
   - component: {fileID: 6746137374291432801}
   - component: {fileID: 676842759937171544}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4821,7 +4821,7 @@ GameObject:
   - component: {fileID: 8640750393553234294}
   - component: {fileID: 931654856800311982}
   - component: {fileID: 6913322856152156435}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4957,7 +4957,7 @@ GameObject:
   - component: {fileID: 7322760094220896883}
   - component: {fileID: 2841532077741495966}
   - component: {fileID: 536980940519660829}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5035,7 +5035,7 @@ GameObject:
   - component: {fileID: 2847662610236741628}
   - component: {fileID: 365944014728797789}
   - component: {fileID: 5991413463410446289}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5156,7 +5156,7 @@ GameObject:
   - component: {fileID: 2238644366431078778}
   - component: {fileID: 6705457330746669225}
   - component: {fileID: 6497703241730211466}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5230,7 +5230,7 @@ GameObject:
   - component: {fileID: 3740303388967801404}
   - component: {fileID: 1497263360503861366}
   - component: {fileID: 54224582460299950}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5353,7 +5353,7 @@ GameObject:
   - component: {fileID: 7144732600677624810}
   - component: {fileID: 8384572772713977261}
   - component: {fileID: 703288787029198106}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: TeleportTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -5464,7 +5464,7 @@ GameObject:
   - component: {fileID: 5947770955900108764}
   - component: {fileID: 896550748813573255}
   - component: {fileID: 7924109979467086646}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5543,7 +5543,7 @@ GameObject:
   - component: {fileID: 4542188870730503728}
   - component: {fileID: 7705951369768132435}
   - component: {fileID: 1499055614960324060}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5615,7 +5615,7 @@ GameObject:
   - component: {fileID: 2520065363894441011}
   - component: {fileID: 4129421149261776099}
   - component: {fileID: 8302522384672194118}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5751,7 +5751,7 @@ GameObject:
   - component: {fileID: 3453159805662793750}
   - component: {fileID: 4702173275122838902}
   - component: {fileID: 8583584421752216280}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5889,7 +5889,7 @@ GameObject:
   - component: {fileID: 6951523529951747135}
   - component: {fileID: 3457279365408480348}
   - component: {fileID: 561850794045612004}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: AirTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -6000,7 +6000,7 @@ GameObject:
   - component: {fileID: 6480988316549324658}
   - component: {fileID: 7445488421794090248}
   - component: {fileID: 4699078344520857344}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6138,7 +6138,7 @@ GameObject:
   - component: {fileID: 8699911491523431287}
   - component: {fileID: 1730777306127255621}
   - component: {fileID: 7931144950744802181}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: StartTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -6249,7 +6249,7 @@ GameObject:
   - component: {fileID: 8924923330626254616}
   - component: {fileID: 5880944554654845471}
   - component: {fileID: 6131218172076515836}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6387,7 +6387,7 @@ GameObject:
   - component: {fileID: 5648385151503442326}
   - component: {fileID: 8725317998415395391}
   - component: {fileID: 4663099311586192595}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: EarthTab
   m_TagString: UIButtonTab
   m_Icon: {fileID: 0}
@@ -6498,7 +6498,7 @@ GameObject:
   - component: {fileID: 487326734285941673}
   - component: {fileID: 2501086520211448609}
   - component: {fileID: 5282510701261206173}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6636,7 +6636,7 @@ GameObject:
   - component: {fileID: 3508928875706243276}
   - component: {fileID: 5432748037258706699}
   - component: {fileID: 8274236955073251973}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Book contents Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6757,7 +6757,7 @@ GameObject:
   - component: {fileID: 28740111413293185}
   - component: {fileID: 2318143333584165746}
   - component: {fileID: 4627499560305296107}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6893,7 +6893,7 @@ GameObject:
   - component: {fileID: 8937337949600262535}
   - component: {fileID: 177489537942181228}
   - component: {fileID: 2219677266068481145}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6965,7 +6965,7 @@ GameObject:
   - component: {fileID: 3382724848175066025}
   - component: {fileID: 3232824115958804435}
   - component: {fileID: 2092231418311207048}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7099,7 +7099,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3311681368025619396}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: FireChapter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7134,7 +7134,7 @@ GameObject:
   - component: {fileID: 2909385993819482211}
   - component: {fileID: 338192575483082553}
   - component: {fileID: 3325681730411564094}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7211,7 +7211,7 @@ GameObject:
   - component: {fileID: 2553022785828500125}
   - component: {fileID: 5829000978218531403}
   - component: {fileID: 5505433403682432073}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: RawImage (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7283,7 +7283,7 @@ GameObject:
   - component: {fileID: 4423795409322402949}
   - component: {fileID: 5283119349785969247}
   - component: {fileID: 3122534985257692837}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7425,7 +7425,7 @@ GameObject:
   - component: {fileID: 4545767621006131867}
   - component: {fileID: 3590663510367163821}
   - component: {fileID: 5916730553410927637}
-  m_Layer: 5
+  m_Layer: 11
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/SpellProjectiles/Basic Spell Projectile.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Basic Spell Projectile.prefab
@@ -88,7 +88,7 @@ SphereCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 520
+    m_Bits: 2568
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0

--- a/Assets/Prefabs/SpellProjectiles/Debug Spell Projectile Variant.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Debug Spell Projectile Variant.prefab
@@ -196,7 +196,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7478003267815051674, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
       propertyPath: m_ExcludeLayers.m_Bits
-      value: 520
+      value: 2568
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/SpellProjectiles/EarthGrow.prefab
+++ b/Assets/Prefabs/SpellProjectiles/EarthGrow.prefab
@@ -160,7 +160,7 @@ Rigidbody:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 2048
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 0

--- a/Assets/Prefabs/SpellProjectiles/EarthShrink.prefab
+++ b/Assets/Prefabs/SpellProjectiles/EarthShrink.prefab
@@ -160,7 +160,7 @@ Rigidbody:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 2048
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 0

--- a/Assets/Prefabs/SpellProjectiles/Fire Spell.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Fire Spell.prefab
@@ -186,6 +186,10 @@ PrefabInstance:
       propertyPath: m_Radius
       value: 0.2
       objectReference: {fileID: 0}
+    - target: {fileID: 7478003267815051674, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 2568
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Assets/Prefabs/SpellProjectiles/Water Projectile.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Water Projectile.prefab
@@ -292,6 +292,10 @@ PrefabInstance:
       propertyPath: m_Radius
       value: 0.05
       objectReference: {fileID: 0}
+    - target: {fileID: 7478003267815051674, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 2568
+      objectReference: {fileID: 0}
     - target: {fileID: 8515777054025704313, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
       propertyPath: m_IsActive
       value: 0

--- a/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab
@@ -286,7 +286,7 @@ MonoBehaviour:
   _pool: 3
   _ignoreLayers:
     serializedVersion: 2
-    m_Bits: 552
+    m_Bits: 2600
 --- !u!114 &-2397331427679202286
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,7 +309,7 @@ MonoBehaviour:
   _speed: 3
   _ignoreLayers:
     serializedVersion: 2
-    m_Bits: 552
+    m_Bits: 2600
 --- !u!1 &7559467922833788076
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -25,7 +25,7 @@ TagManager:
   - Teleportable surface
   - Spell
   - Resizable
-  - 
+  - Grimoire
   - 
   - 
   - 


### PR DESCRIPTION

## Content

Spells now ignore the grimoire and pass right through

## Changes
### Added
`Grimoire layer` : Was created
### Updated
`Assets/Prefabs/Grimiore/Bookholder.prefab` : Was updated to have the grimoire layer
`Assets/Prefabs/SpellProjectiles/Basic Spell Projectile.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/Debug Spell Projectile Variant.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/EarthGrow.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/EarthShrink.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/Fire Spell.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/Water Projectile.prefab` : Was updated to ignore the grimoire layer
`Assets/Prefabs/SpellProjectiles/Wind Spell Ranged.prefab` : Was updated to ignore the grimoire layer
 
`ProjectSettings/TagManager.asset` : Was updated to have grimoire layer


## Testing

The feature / Bugfix can be testing by following these steps:

1. Just play the game via main level
2. Open grimoire
3. Try to hit it with a spell
Closes #185 
