### PR TITLE
✨ Final spell

### DIFF
--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
-using UnityEngine.XR.Interaction.Toolkit.AR;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 {
@@ -26,37 +25,35 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         private HandShape _rightHandShape;
         private bool _gestureValidated = false;
         private bool _sequenceStarted = false;
-        [SerializeField] private bool _canQuickCast = false;
+        private bool _canQuickCast = false;
 
-        internal event Action OnSequenceCreated;
-        internal event Action OnReset;
-        internal event Action OnQuickCast;
-        internal event Action<Gesture> OnGestureRecognised;
-        internal event Action<Gesture> OnElementValidated;
-        internal event Action OnSpellFailedVFX;
+        internal event Action onSequenceCreated;
+        internal event Action onReset;
+        internal event Action onQuickCast;
+        internal event Action<List<Gesture>> OnGestureRecognised;
+        internal event Action<Gesture> onElementValidated;
+        internal event Action onSpellFailedVFX;
 
         internal List<Gesture> ValidatedGestures => _validatedGestures;
 
         private void Awake()
         {
             _cancellationTokenSource = new CancellationTokenSource();
-            SpellManager.OnSpellValidation += HandleOnSpellValidated;
-            SpellManager.OnSpellFailed += HandleOnSpellFailed;
-            
+            SpellManager.onSpellValidation += HandleOnSpellValidated;
+            SpellManager.onNoSpellMatch += HandleOnSpellFailed;
+
             _defaultColor = _rightHandMaterial.materials[1].GetColor("_MainColor");
         }
 
         private void OnDestroy()
         {
-            SpellManager.OnSpellFailed -= HandleOnSpellFailed;
-            SpellManager.OnSpellValidation -= HandleOnSpellValidated;
+            SpellManager.onSpellValidation -= HandleOnSpellValidated;
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
         }
 
         private void FixedUpdate()
         {
-            Debug.Log(_validatedGestures.Count);
             if (_leftHandActive && _rightHandActive && !_gestureValidated && _currentGesture != null)
                 HandDistanceCheck(_currentGesture);
         }
@@ -78,52 +75,51 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 
         private void OnDistanceValidated()
         {
-            if (_currentGesture != null)
-            {
-                if (_currentGesture._name == "Start" && _leftHandActive && _rightHandActive &&
-                    _currentGesture._leftHandShape == HandShape.Start && _currentGesture._rightHandShape == HandShape.Start)
-                {
-                    _validatedGestures.Clear();
-                    OnReset?.Invoke();
-                    _sequenceStarted = true;
-                    _canQuickCast = false;
-                    
-                    OnElementValidated?.Invoke(_currentGesture);
-                }
-                else if (_canQuickCast && _currentGesture._name == "Quick Cast" && _leftHandActive &&
-                    _rightHandActive && _currentGesture._leftHandShape == HandShape.QuickCast &&
-                    _currentGesture._rightHandShape == HandShape.QuickCast)
-                {
-                    _validatedGestures.Clear();
-                    OnQuickCast?.Invoke();
-                    
-                    OnElementValidated?.Invoke(_currentGesture);
-                }
+            if (_currentGesture == null) return;
 
-                if (_sequenceStarted && _validatedGestures.Count == 0 ||
-                    _sequenceStarted && _validatedGestures[^1] != _currentGesture &&
-                    _rightHandShape != HandShape.QuickCast && _leftHandShape != HandShape.QuickCast)
+            HandleGesture(_currentGesture);
+
+            if (_sequenceStarted)
+            {
+                if (_validatedGestures.Count == 0 ||
+                    _validatedGestures[^1] != _currentGesture)
                 {
                     _validatedGestures.Add(_currentGesture);
+                    OnGestureRecognised?.Invoke(_validatedGestures);
                     ChangeColor(_cancellationTokenSource.Token);
-                    OnGestureRecognised?.Invoke(_currentGesture);
-                }
 
-                if (_validatedGestures.Count == 2)
-                {
-                    OnElementValidated?.Invoke(_currentGesture);
+                    if (_validatedGestures.Count == 2)
+                        onElementValidated?.Invoke(_currentGesture);
                 }
-                
-                if (_validatedGestures.Count == 3)
-                {
-                    OnSequenceCreated?.Invoke();
-                    _sequenceStarted = false;
-                    _validatedGestures.Clear();
-                }
-
-                _currentGesture = null;
-                _gestureValidated = false;
             }
+
+            _currentGesture = null;
+            _gestureValidated = false;
+        }
+
+        private void HandleGesture(Gesture currentGesture)
+        {
+            if (_leftHandActive && _rightHandActive)
+                switch (currentGesture._name)
+                {
+                    case "Start":
+                        _validatedGestures.Clear();
+                        onReset?.Invoke();
+                        _sequenceStarted = true;
+                        _canQuickCast = false;
+                        onElementValidated?.Invoke(currentGesture);
+                        break;
+                    case "Quick Cast":
+                        if (_canQuickCast)
+                        {
+                            _validatedGestures.Clear();
+                            onQuickCast?.Invoke();
+                            onElementValidated?.Invoke(currentGesture);
+                        }
+                        break;
+                    default:
+                        return;
+                }
         }
 
         private void HandDistanceCheck(Gesture gesture)
@@ -146,7 +142,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         {
             try
             {
-                if (_validatedGestures.Count < 3 && _validatedGestures.Count > 0)
+                if (_sequenceStarted)
                 {
                     float delay = 1;
 
@@ -158,11 +154,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                     _rightHandMaterial.materials[1].SetColor("_MainColor", _defaultColor);
                     _leftHandMaterial.materials[1].SetColor("_MainColor", _defaultColor);
                 }
-                else
-                {
-                    _rightHandMaterial.materials[1].SetColor("_MainColor", _currentGesture._color);
-                    _leftHandMaterial.materials[1].SetColor("_MainColor", _currentGesture._color);
-                }
             }
             catch (OperationCanceledException)
             {
@@ -173,14 +164,16 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         private void HandleOnSpellValidated(bool value)
         {
             _canQuickCast = value;
+            _validatedGestures.Clear();
+            _sequenceStarted = false;
         }
 
-       private void HandleOnSpellFailed()
-       {
-           _validatedGestures.Clear(); 
-           _sequenceStarted = false; 
-           OnSpellFailedVFX?.Invoke(); // Invoke the event to disable VFX on hands
-       }
+        private void HandleOnSpellFailed()
+        {
+            _validatedGestures.Clear();
+            _sequenceStarted = false;
+            onSpellFailedVFX?.Invoke(); // Invoke the event to disable VFX on hands
+        }
 
         public void SetRightHandShape(string handShape)
         {

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -1,16 +1,10 @@
-using UnityEngine;
-using RogueApeStudios.SecretsOfIgnacios.Spells;
-using RogueApeStudios.SecretsOfIgnacios.Gestures;
 using Cysharp.Threading.Tasks;
-using System.Threading;
+using RogueApeStudios.SecretsOfIgnacios.Gestures;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
 using System;
 using System.Threading;
-using Cysharp.Threading.Tasks;
-using RogueApeStudios.SecretsOfIgnacios.Gestures;
-using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
 using UnityEngine.VFX;
-using NUnit.Framework.Internal;
 using UnityEngine.XR.Hands;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
@@ -24,16 +18,16 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
 
         [SerializeField] private GameObject _prefabContainerL; // a container for the vfx. This is the one moving. This can be turned off with the public function
-        [SerializeField] private GameObject _prefabContainerR; 
-        [SerializeField] private Transform  _palmL; 
-        [SerializeField] private Transform  _palmR; 
-        [SerializeField] private GameObject _magicCircleTarget; 
+        [SerializeField] private GameObject _prefabContainerR;
+        [SerializeField] private Transform _palmL;
+        [SerializeField] private Transform _palmR;
+        [SerializeField] private GameObject _magicCircleTarget;
 
         [SerializeField] private SequenceManager _sequenceManager;
         [SerializeField] private Cast _castscript;
 
 
-        private VisualEffect _currentEffectL; 
+        private VisualEffect _currentEffectL;
         private VisualEffect _currentEffectR;
         private Gesture _lastGesture;
 
@@ -52,21 +46,21 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
             //unsubscribe
-            SpellManager.OnSpellValidation -= HandleCastRecognized;
-            SpellManager.OnSpellFailed -= SpellManagerOnOnSpellFailed;
-            _sequenceManager.OnElementValidated -= HandleElementRecognized;
-            
+            SpellManager.onSpellValidation -= HandleCastRecognized;
+            SpellManager.onNoSpellMatch -= SpellManagerOnOnSpellFailed;
+            _sequenceManager.onElementValidated -= HandleElementRecognized;
+
             _castscript.onSpellCastComplete -= DisableHandVFX;
             //unsubscribe from cast script's cast finished event (event on cast not implemented)
         }
 
         private void SpellManagerOnOnSpellFailed()
-        { 
-            if(_currentEffectL != null) 
-            { 
+        {
+            if (_currentEffectL != null)
+            {
                 _currentEffectL.Stop();
             }
-            if(_currentEffectR != null) 
+            if (_currentEffectR != null)
             {
                 _currentEffectR.Stop();
             }
@@ -75,9 +69,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
         void Start()
         {
             //subscribe!
-            SpellManager.OnSpellValidation += HandleCastRecognized;
-            SpellManager.OnSpellFailed += SpellManagerOnOnSpellFailed;
-            _sequenceManager.OnElementValidated += HandleElementRecognized;
+            SpellManager.onSpellValidation += HandleCastRecognized;
+            SpellManager.onNoSpellMatch += SpellManagerOnOnSpellFailed;
+            _sequenceManager.onElementValidated += HandleElementRecognized;
             _castscript.onSpellCastComplete += DisableHandVFX;
             //subscribe to cast script's cast finished event (event on cast not implemented)
         }
@@ -91,11 +85,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             {
                 case HandShape.Start:
                     //disable all hand effects
-                    if(_currentEffectL != null)
+                    if (_currentEffectL != null)
                     {
                         _currentEffectL.Stop();
                     }
-                    if(_currentEffectR != null)
+                    if (_currentEffectR != null)
                     {
                         _currentEffectR.Stop();
                     }
@@ -115,7 +109,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
                     }
                     break;
             }
-            if (r != null && l != null) { //This sets a timer on the visual effect to destroy when it is done playing.
+            if (r != null && l != null)
+            { //This sets a timer on the visual effect to destroy when it is done playing.
                 DestroyVisualEffectWhenDone(_cancellationTokenSource.Token, r);
                 DestroyVisualEffectWhenDone(_cancellationTokenSource.Token, l);
 

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
@@ -1,5 +1,6 @@
 using RogueApeStudios.SecretsOfIgnacios.Gestures;
 using RogueApeStudios.SecretsOfIgnacios.Spells;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.VFX;
 
@@ -23,40 +24,44 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
 
         private void Start()
         {
-            //sub to the gesture recognized and spell recognized events
             _magicCircle.Stop();
-            SpellManager.OnSpellValidation += HandleSpellRecognized;
-            SpellManager.OnSpellFailed += HandleSpellFailed;
+
+            //sub to the gesture recognized and spell recognized events
+            SpellManager.onSpellValidation += HandleSpellRecognized;
+            SpellManager.onNoSpellMatch += HandleSpellFailed;
             _sequenceManager.OnGestureRecognised += HandleGestureRecognized;
         }
         private void OnDestroy()
         {
             //unsubscribe
-            SpellManager.OnSpellValidation -= HandleSpellRecognized;
+            SpellManager.onSpellValidation -= HandleSpellRecognized;
+            SpellManager.onNoSpellMatch -= HandleSpellFailed;
             _sequenceManager.OnGestureRecognised -= HandleGestureRecognized;
-
         }
 
-        void HandleGestureRecognized(Gesture gesture)
+        void HandleGestureRecognized(List<Gesture> gesture)
         {
-            switch (gesture._rightHandShape)
+            if (gesture.Count > 0)
             {
-                case HandShape.Start:
-                    _boolControls.SetActive(true);
-                    _magicCircle.Play();
-                    break;
-                case HandShape.Fire:
-                    break;
-                case HandShape.Water:
-                    break;
-                case HandShape.Earth:
-                    break;
-                case HandShape.Air:
-                    break;
-                default:
-                    break;
+                switch (gesture[^1]._rightHandShape)
+                {
+                    case HandShape.Start:
+                        _boolControls.SetActive(true);
+                        _magicCircle.Play();
+                        break;
+                    case HandShape.Fire:
+                        break;
+                    case HandShape.Water:
+                        break;
+                    case HandShape.Earth:
+                        break;
+                    case HandShape.Air:
+                        break;
+                    default:
+                        break;
+                }
+                _colorControls.startColor = gesture[^1]._color;
             }
-            _colorControls.startColor = gesture._color;
         }
 
         void HandleSpellRecognized(bool recognized)

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -26,7 +26,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
         private void Awake()
         {
-            SpellManager.OnSpellValidation += HandleSpellValidation;
+            SpellManager.onSpellValidation += HandleSpellValidation;
 
             _cancellationTokenSource = new CancellationTokenSource();
         }
@@ -39,7 +39,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
         private void OnDestroy()
         {
-            SpellManager.OnSpellValidation -= HandleSpellValidation;
+            SpellManager.onSpellValidation -= HandleSpellValidation;
 
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -1,7 +1,7 @@
 using Cysharp.Threading.Tasks;
 using RogueApeStudios.SecretsOfIgnacios.Gestures;
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 
@@ -19,14 +19,13 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [Header("Spells")]
         [SerializeField] private Spell[] _availableSpells;
 
-
         private Spell _currentSpell;
         private Spell _lastSpell;
         private CancellationTokenSource _cancellationTokenSource;
         private Color _defaultColor;
 
-        public static event Action<bool> OnSpellValidation;
-        public static event Action OnSpellFailed;
+        public static event Action<bool> onSpellValidation;
+        public static event Action onNoSpellMatch;
 
         internal Spell CurrentSpell => _currentSpell;
         internal Color DefaultColor => _defaultColor;
@@ -43,48 +42,86 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
         private void OnEnable()
         {
-            _sequenceManager.OnSequenceCreated += ValidateSequence;
-            _sequenceManager.OnReset += HandleReset;
-            _sequenceManager.OnQuickCast += HandleOnQuickCast;
+            _sequenceManager.OnGestureRecognised += CheckSequence;
+            _sequenceManager.onReset += HandleReset;
+            _sequenceManager.onQuickCast += HandleOnQuickCast;
         }
 
         private void OnDestroy()
         {
-            _sequenceManager.OnSequenceCreated -= ValidateSequence;
-            _sequenceManager.OnReset -= HandleReset;
+            _sequenceManager.OnGestureRecognised -= CheckSequence;
+            _sequenceManager.onReset -= HandleReset;
+            _sequenceManager.onQuickCast -= HandleOnQuickCast;
 
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
         }
 
-        public void ValidateSequence()
+        public void CheckSequence(List<Gesture> performedGestures)
         {
-            bool spellFound = false;
+            Spell exactMatch = GetExactMatchingSpell(performedGestures);
+            bool hasPartialMatch = HasPartialMatchingSpell(performedGestures);
 
-            foreach (var spell in _availableSpells)
-                if (spell._gestureSequence.Count == _sequenceManager.ValidatedGestures.Count &&
-                    spell._gestureSequence.SequenceEqual(_sequenceManager.ValidatedGestures))
-                {
-                    SetSpell(spell);
-                    spellFound = true;
-                    break;
-                }
-
-            if (!spellFound)
+            if (exactMatch != null)
+            {
+                SetSpell(exactMatch);
+                onSpellValidation?.Invoke(true);
+            }
+            else if (!hasPartialMatch)
             {
                 _currentSpell = null;
-                OnSpellFailed?.Invoke();
                 SpellWrongIndication(_cancellationTokenSource.Token);
+                onNoSpellMatch?.Invoke();
             }
-            else
-                OnSpellValidation?.Invoke(spellFound);
+            // If there is a partial match, do nothing and wait for more gestures.
+        }
+
+        private Spell GetExactMatchingSpell(List<Gesture> performedGestures)
+        {
+            foreach (Spell spell in _availableSpells)
+                if (IsExactMatch(spell, performedGestures))
+                    return spell;
+
+            return null;
+        }
+
+        private bool HasPartialMatchingSpell(List<Gesture> performedGestures)
+        {
+            foreach (Spell spell in _availableSpells)
+                if (IsPartialMatch(spell, performedGestures))
+                    return true;
+
+            return false;
+        }
+
+        private bool IsExactMatch(Spell spell, List<Gesture> performedGestures)
+        {
+            if (performedGestures.Count != spell._gestureSequence.Count)
+                return false;
+
+            for (int i = 0; i < spell._gestureSequence.Count; i++)
+                if (spell._gestureSequence[i] != performedGestures[i])
+                    return false;
+
+            return true;
+        }
+
+        private bool IsPartialMatch(Spell spell, List<Gesture> performedGestures)
+        {
+            if (performedGestures.Count >= spell._gestureSequence.Count)
+                return false;
+
+            for (int i = 0; i < performedGestures.Count; i++)
+                if (spell._gestureSequence[i] != performedGestures[i])
+                    return false;
+
+            return true;
         }
 
         private void SetSpell(Spell spell)
         {
             _currentSpell = spell;
             _lastSpell = spell;
-
             SetHandEffects(true);
         }
 
@@ -119,7 +156,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
             SetHandEffects(false);
 
-            OnSpellValidation?.Invoke(false);
+            onSpellValidation?.Invoke(false);
         }
 
         private void HandleOnQuickCast()
@@ -128,7 +165,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
             SetHandEffects(true);
 
-            OnSpellValidation?.Invoke(true);
+            onSpellValidation?.Invoke(true);
         }
 
         private void SetHandEffects(bool isDefaultColor)


### PR DESCRIPTION
## Content

Updated gesture sequence creation and recognition system. It can now recognise infinitely long sequences, if the player performs 1 wrong gesture and no other sequence partially matches it, the wrong indication will be shown. 

## Changes

### Updated
`Assets/Scripts/Gestures/SequenceManager.cs` : Was updated / renamed. No longer hard coded for 3 gestures.
`Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs` : Was updated / renamed. It just subscribed to the new event, nothing else changed, except formatting apparently.
`Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs` : Was updated / renamed. Event got a new parameter, so this had to be updated.
`Assets/Scripts/Spells/Cast.cs` : Was updated / renamed. Event names were changed according to code convention, this script was subscribed to them.
`Assets/Scripts/Spells/SpellManager.cs` : Was updated / renamed. Checks after every valid gesture if a spell partially matches or exactly matches.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Drag in player rig
2. Change a spell SO so it has more than 3 gestures (Make sure to not have the same gesture back to back, there is a check for it, it will not be recognised)
3. Do the spell
4. Profit

Closes #47 
