### PR TITLE
🎨 Gloom stalk size

### DIFF
--- a/Assets/Prefabs/Puzzles/FireRoom/GloomStalk.prefab
+++ b/Assets/Prefabs/Puzzles/FireRoom/GloomStalk.prefab
@@ -225,6 +225,18 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.206
       objectReference: {fileID: 0}
@@ -263,6 +275,10 @@ PrefabInstance:
     - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495720, guid: 20e0bf298681fcd4693097c822277593, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
## Content

Reduced gloom stalk size from 1 to 0.25.

## Changes

### Updated
`Assets/Prefabs/Puzzles/FireRoom/GloomStalk.prefab` : Was updated / renamed. Reduced size.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Go to main level
2. Burn gloom stalk
3. See if you agree with the size

Closes #169 
