### PR TITLE
♻️ Hand vfx manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]andbox.meta
 
 .utmp/
+Assets/Fonts/Parisienne-Regular SDF.asset

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -9,7 +9,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 {
     internal class SequenceManager : MonoBehaviour
     {
-        [SerializeField] private HandVfxManager _vfxManager;
+        [SerializeField] private HandVfxManager _handVfxManager;
 
         [SerializeField] private Transform _rightHand;
         [SerializeField] private Transform _leftHand;
@@ -18,7 +18,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         [SerializeField] private List<Gesture> _allGestures;
         [SerializeField] private bool _leftHandActive = false; // Only serialized for testing purposes
         [SerializeField] private bool _rightHandActive = false; // Only serialized for testing purposes
-        [SerializeField] private Material _defaultMaterial;
 
         private readonly List<Gesture> _validatedGestures = new();
         private CancellationTokenSource _cancellationTokenSource;
@@ -32,7 +31,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
         internal event Action onSequenceCreated;
         internal event Action onReset;
         internal event Action onQuickCast;
-        internal event Action<List<Gesture>> OnGestureRecognised;
+        internal event Action<List<Gesture>> onGestureRecognised;
         internal event Action<Gesture> onElementValidated;
         internal event Action onSpellFailedVFX;
 
@@ -86,11 +85,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                     _validatedGestures[^1] != _currentGesture)
                 {
                     _validatedGestures.Add(_currentGesture);
-                    ChangeColor();
-                    OnGestureRecognised?.Invoke(_validatedGestures);
+                    _handVfxManager.ChangeColorOnGesture(_currentGesture);
+                    onGestureRecognised?.Invoke(_validatedGestures);
 
                     if (_validatedGestures.Count == 2)
-                        _vfxManager.HandleElementRecognized(_currentGesture);
+                        _handVfxManager.HandleElementRecognized(_currentGesture);
                 }
             }
 
@@ -108,14 +107,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                         onReset?.Invoke();
                         _sequenceStarted = true;
                         _canQuickCast = false;
-                        onElementValidated?.Invoke(currentGesture);
+                        _handVfxManager.HandleElementRecognized(_currentGesture);
                         break;
                     case "Quick Cast":
                         if (_canQuickCast)
                         {
                             _validatedGestures.Clear();
                             onQuickCast?.Invoke();
-                            onElementValidated?.Invoke(currentGesture);
+                            _handVfxManager.HandleElementRecognized(_currentGesture);
                         }
                         break;
                     default:
@@ -136,17 +135,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
             {
                 _gestureValidated = true;
                 OnDistanceValidated();
-            }
-        }
-
-        private void ChangeColor()
-        {
-            if (_sequenceStarted)
-            {
-                _rightHandMaterial.materials[1].SetColor("_MainColor", _currentGesture._color);
-                _leftHandMaterial.materials[1].SetColor("_MainColor", _currentGesture._color);
-                _rightHandMaterial.material = _defaultMaterial;
-                _leftHandMaterial.material = _defaultMaterial;
             }
         }
 

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -86,7 +86,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                 {
                     _validatedGestures.Add(_currentGesture);
                     _handVfxManager.ChangeColorOnGesture(_currentGesture);
-                    onGestureRecognised?.Invoke(_validatedGestures);
+
+                    if (_currentGesture._name != "Quick Cast")
+                        onGestureRecognised?.Invoke(_validatedGestures);
 
                     if (_validatedGestures.Count == 2)
                         _handVfxManager.HandleElementRecognized(_currentGesture);

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -1,3 +1,4 @@
+using RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle;
 using RogueApeStudios.SecretsOfIgnacios.Spells;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 {
     internal class SequenceManager : MonoBehaviour
     {
+        [SerializeField] private HandVfxManager _vfxManager;
+
         [SerializeField] private Transform _rightHand;
         [SerializeField] private Transform _leftHand;
         [SerializeField] private Renderer _rightHandMaterial;
@@ -87,7 +90,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                     OnGestureRecognised?.Invoke(_validatedGestures);
 
                     if (_validatedGestures.Count == 2)
-                        onElementValidated?.Invoke(_currentGesture);
+                        _vfxManager.HandleElementRecognized(_currentGesture);
                 }
             }
 

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -114,7 +114,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
                         {
                             _validatedGestures.Clear();
                             onQuickCast?.Invoke();
-                            _handVfxManager.HandleElementRecognized(_currentGesture);
                         }
                         break;
                     default:
@@ -138,9 +137,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
             }
         }
 
-        private void HandleOnSpellValidated(bool value)
+        private void HandleOnSpellValidated()
         {
-            _canQuickCast = value;
+            _canQuickCast = true;
             _validatedGestures.Clear();
             _sequenceStarted = false;
         }

--- a/Assets/Scripts/Gestures/SequenceManager.cs
+++ b/Assets/Scripts/Gestures/SequenceManager.cs
@@ -13,8 +13,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Gestures
 
         [SerializeField] private Transform _rightHand;
         [SerializeField] private Transform _leftHand;
-        [SerializeField] private Renderer _rightHandMaterial;
-        [SerializeField] private Renderer _leftHandMaterial;
         [SerializeField] private List<Gesture> _allGestures;
         [SerializeField] private bool _leftHandActive = false; // Only serialized for testing purposes
         [SerializeField] private bool _rightHandActive = false; // Only serialized for testing purposes

--- a/Assets/Scripts/Player/HandData.cs
+++ b/Assets/Scripts/Player/HandData.cs
@@ -17,7 +17,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
         [SerializeField] internal Renderer _renderer;
         [SerializeField] internal VisualEffect _chargeEffect;
 
-        internal VisualEffect _currentEffect;
+        internal GameObject _currentEffect;
         internal Material _defaultMaterial;
         internal Transform _spellPrefab;
         internal Color _defaultColor;
@@ -42,6 +42,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
                 else
                     return spellManager.CurrentSpell._secondaryConfig;
             }
+        }
+
+        internal void TogglePrefabContainer(bool active)
+        {
+            _prefabContainer.SetActive(active);
         }
     }
 }

--- a/Assets/Scripts/Player/HandData.cs
+++ b/Assets/Scripts/Player/HandData.cs
@@ -7,17 +7,29 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
     public class HandData : MonoBehaviour
     {
         [Header("References")]
-        [SerializeField] internal Transform _handTransform;
+        [SerializeField] internal GameObject _prefabContainer;
+        [SerializeField] internal LineRenderer _lineRenderer;
+        [SerializeField] internal Transform _prefabContainerTransform;
+        [SerializeField] internal Transform _palmTransform;
+        [SerializeField] internal Transform _spellSpawnPoint;
 
         [Header("Visual")]
-        [SerializeField] internal VisualEffect _chargeEffect;
-        [SerializeField] internal VisualEffect _currentEffect;
-        [SerializeField] internal GameObject _prefabContainer;
-        [SerializeField] internal Transform _prefabContainerTransform;
-        [SerializeField] internal Transform _palm;
-        [SerializeField] internal LineRenderer _lineRenderer;
         [SerializeField] internal Renderer _renderer;
-        [SerializeField] internal Material _material;
+        [SerializeField] internal VisualEffect _chargeEffect;
+
+        internal VisualEffect _currentEffect;
+        internal Material _defaultMaterial;
+        internal Transform _spellPrefab;
+        internal Color _defaultColor;
+        internal bool _canCast = false;
+        internal bool _isCasting = false;
+
+        private void Start()
+        {
+            _chargeEffect.Stop();
+            _defaultMaterial = _renderer.material;
+            _defaultColor = _renderer.materials[1].GetColor("_MainColor");
+        }
 
         internal HandConfig GetHandConfig(SpellManager spellManager, bool isRightHand)
         {

--- a/Assets/Scripts/Player/HandData.cs
+++ b/Assets/Scripts/Player/HandData.cs
@@ -1,0 +1,35 @@
+using RogueApeStudios.SecretsOfIgnacios.Spells;
+using UnityEngine;
+using UnityEngine.VFX;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Player
+{
+    public class HandData : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] internal Transform _handTransform;
+
+        [Header("Visual")]
+        [SerializeField] internal VisualEffect _chargeEffect;
+        [SerializeField] internal VisualEffect _currentEffect;
+        [SerializeField] internal GameObject _prefabContainer;
+        [SerializeField] internal Transform _prefabContainerTransform;
+        [SerializeField] internal Transform _palm;
+        [SerializeField] internal LineRenderer _lineRenderer;
+        [SerializeField] internal Renderer _renderer;
+        [SerializeField] internal Material _material;
+
+        internal HandConfig GetHandConfig(SpellManager spellManager, bool isRightHand)
+        {
+            if (!spellManager.CurrentSpell._duoSpell)
+                return spellManager.CurrentSpell._primaryConfig;
+            else
+            {
+                if (isRightHand)
+                    return spellManager.CurrentSpell._primaryConfig;
+                else
+                    return spellManager.CurrentSpell._secondaryConfig;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Player/HandData.cs.meta
+++ b/Assets/Scripts/Player/HandData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 140dabe378c14e94f9c23cde06c99199

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -1,5 +1,6 @@
 using Cysharp.Threading.Tasks;
 using RogueApeStudios.SecretsOfIgnacios.Gestures;
+using RogueApeStudios.SecretsOfIgnacios.Services;
 using RogueApeStudios.SecretsOfIgnacios.Spells;
 using System;
 using System.Threading;
@@ -25,14 +26,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
         [SerializeField] private SequenceManager _sequenceManager;
         [SerializeField] private Cast _castscript;
+        [SerializeField] private ObjectPooler _objectPooler;
 
         [SerializeField] private HandData _handDataRight;
         [SerializeField] private HandData _handDataLeft;
 
-        private VisualEffect _currentEffectL;
-        private VisualEffect _currentEffectR;
         private Gesture _lastGesture;
-
+        private GameObject _visualEffectRight;
+        private GameObject _visualEffectLeft;
         private CancellationTokenSource _cancellationTokenSource;
 
         private void Awake()
@@ -58,81 +59,32 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
         internal void HandleElementRecognized(Gesture gesture)
         {
-            if (gesture._rightHandShape == HandShape.Start)
+            if (gesture._name == "Start")
             {
                 DisableBothHandEffects();
                 return;
             }
 
-            // QuickCast logic can be added here if needed.
-            if (gesture._rightHandShape == HandShape.QuickCast)
+            if (gesture._name == "Quick Cast")
                 return;
 
             if (gesture._visualEffectPrefab == null)
                 return;
 
-            // Instantiate visual effects for both hands
-            GameObject visualEffectRight = Instantiate(gesture._visualEffectPrefab, _handDataRight._prefabContainerTransform);
-            GameObject visualEffectLeft = Instantiate(gesture._visualEffectPrefab, _handDataLeft._prefabContainerTransform);
-
-            _lastGesture = gesture;
             SetVFXContainerPositions();
 
-            // Handle destroying and assigning effects
-            AssignAndDestroyVisualEffect(visualEffectRight, _handDataRight);
-            AssignAndDestroyVisualEffect(visualEffectLeft, _handDataLeft);
+            _lastGesture = gesture;
         }
 
-        private void AssignAndDestroyVisualEffect(GameObject visualEffect, HandData handData)
+        private void AssignEffect(GameObject visualEffect, HandData handData)
         {
             if (visualEffect == null)
                 return;
 
-            DestroyVisualEffectWhenDone(_cancellationTokenSource.Token, visualEffect);
+            ReturnVisualEffect(_cancellationTokenSource.Token, visualEffect);
 
             if (visualEffect.TryGetComponent<VisualEffect>(out VisualEffect visual))
-            {
-                if (handData._currentEffect != null)
-                    handData._currentEffect.Stop();
-
                 handData._currentEffect = visual;
-            }
-        }
-
-        public void HandleQuickCast() //will subscribe to quick cast event
-        {
-            if (_lastGesture != null && _lastGesture._visualEffectPrefab != null)
-            {
-                GameObject visualEffectRight = Instantiate(_lastGesture._visualEffectPrefab, _handDataRight._prefabContainerTransform, false);
-                GameObject visualEffectLeft = Instantiate(_lastGesture._visualEffectPrefab, _handDataLeft._prefabContainerTransform, false);
-                SetVFXContainerPositions();
-
-                DestroyVisualEffectWhenDone(_cancellationTokenSource.Token, visualEffectRight);
-                DestroyVisualEffectWhenDone(_cancellationTokenSource.Token, visualEffectLeft);
-
-                //assign current effect
-                if (visualEffectRight.TryGetComponent<VisualEffect>(out VisualEffect visualr))
-                {
-                    if (_handDataRight._currentEffect != null)
-                        _handDataRight._currentEffect.Stop();
-
-                    _handDataRight._currentEffect = visualr;
-                }
-                if (visualEffectLeft.TryGetComponent<VisualEffect>(out VisualEffect visuall))
-                {
-                    if (_handDataLeft._currentEffect != null)
-                        _handDataLeft._currentEffect.Stop();
-
-                    _handDataLeft._currentEffect = visuall;
-                }
-
-                MoveVfxToHand(_cancellationTokenSource.Token,
-                    _handDataRight._prefabContainerTransform,
-                    _handDataRight._palmTransform);
-                MoveVfxToHand(_cancellationTokenSource.Token,
-                    _handDataLeft._prefabContainerTransform,
-                    _handDataLeft._palmTransform);
-            }
         }
 
         private void SetVFXContainerPositions()
@@ -141,7 +93,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             _handDataLeft._prefabContainerTransform.parent = _magicCircleTarget;
             _handDataRight._prefabContainerTransform.localPosition = Vector3.zero;
             _handDataLeft._prefabContainerTransform.localPosition = Vector3.zero;
-            _handDataRight._prefabContainer.SetActive(true);
         }
 
         #endregion
@@ -150,7 +101,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
         internal void HandleOnSpellFailed()
         {
-            DisableBothHandEffects();
             SpellWrongIndication(_cancellationTokenSource.Token);
         }
 
@@ -180,58 +130,84 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             }
         }
 
-        internal void SetHandEffects(bool isDefaultColor, Spell currentSpell, bool usedQuickCast)
+        internal void SetHandEffects(Spell currentSpell, bool usedQuickCast)
         {
-            if (isDefaultColor)
-            {
-                if (currentSpell._duoSpell)
-                {
-                    _handDataRight._renderer.material = currentSpell._primaryConfig._handMaterial;
-                    _handDataRight._renderer.materials[1].SetColor("_MainColor", currentSpell._primaryConfig._handColor);
-                    _handDataLeft._renderer.material = currentSpell._secondaryConfig._handMaterial;
-                    _handDataLeft._renderer.materials[1].SetColor("_MainColor", currentSpell._secondaryConfig._handColor);
-                }
-                else
-                {
-                    _handDataRight._renderer.material = currentSpell._primaryConfig._handMaterial;
-                    _handDataRight._renderer.materials[1].SetColor("_MainColor", currentSpell._primaryConfig._handColor);
-                    _handDataLeft._renderer.material = currentSpell._primaryConfig._handMaterial;
-                    _handDataLeft._renderer.materials[1].SetColor("_MainColor", currentSpell._primaryConfig._handColor);
-                }
+            SetHandMaterials(currentSpell);
 
-                _handDataLeft._prefabContainer.SetActive(true);
-                _handDataRight._prefabContainer.SetActive(true);
+            _visualEffectRight = SetupVisualEffect(_handDataRight, _lastGesture);
+            _visualEffectLeft = SetupVisualEffect(_handDataLeft, _lastGesture);
 
-                if (!usedQuickCast)
-                {
-                    MoveVfxToHand(_cancellationTokenSource.Token, _handDataRight._prefabContainerTransform, _handDataRight._palmTransform);
-                    MoveVfxToHand(_cancellationTokenSource.Token, _handDataLeft._prefabContainerTransform, _handDataLeft._palmTransform);
-                }
-            }
-            else
+            _handDataRight._prefabContainer.SetActive(true);
+            _handDataLeft._prefabContainer.SetActive(true);
+
+            _visualEffectRight.transform.SetParent(_handDataRight._prefabContainerTransform);
+            _visualEffectLeft.transform.SetParent(_handDataLeft._prefabContainerTransform);
+
+            if (!usedQuickCast)
             {
-                _handDataRight._renderer.materials[1].SetColor("_MainColor", _handDataRight._defaultColor);
-                _handDataLeft._renderer.materials[1].SetColor("_MainColor", _handDataLeft._defaultColor);
+                MoveVfxToHand(_cancellationTokenSource.Token,
+                    _handDataRight._prefabContainerTransform,
+                    _handDataRight._palmTransform);
+                MoveVfxToHand(_cancellationTokenSource.Token,
+                    _handDataLeft._prefabContainerTransform,
+                    _handDataLeft._palmTransform);
             }
         }
 
-        private async void MoveVfxToHand(CancellationToken token, Transform effect, Transform dest)
+        private void SetHandMaterials(Spell currentSpell)
+        {
+            ApplyMaterialAndColor(_handDataRight, currentSpell._primaryConfig);
+
+            if (currentSpell._duoSpell)
+                ApplyMaterialAndColor(_handDataLeft, currentSpell._secondaryConfig);
+            else
+                ApplyMaterialAndColor(_handDataLeft, currentSpell._primaryConfig);
+        }
+
+        private void ApplyMaterialAndColor(HandData handData, HandConfig config)
+        {
+            handData._renderer.material = config._handMaterial;
+            handData._renderer.materials[1].SetColor("_MainColor", config._handColor);
+        }
+
+        private GameObject SetupVisualEffect(HandData handData, Gesture gesture)
+        {
+            if (gesture._visualEffectPrefab != null)
+            {
+                GameObject visualEffect = _objectPooler.GetObject(gesture._visualEffectPrefab.name,
+                    gesture._visualEffectPrefab, handData._prefabContainerTransform);
+
+                AssignEffect(visualEffect, handData);
+
+                return visualEffect;
+            }
+
+            return null;
+        }
+
+        internal void ResetHandColors()
+        {
+            _handDataRight._renderer.materials[1].SetColor("_MainColor", _handDataRight._defaultColor);
+            _handDataLeft._renderer.materials[1].SetColor("_MainColor", _handDataLeft._defaultColor);
+        }
+
+        private async void MoveVfxToHand(CancellationToken token, Transform prefabContainer, Transform dest)
         {
             try
             {
                 float delay = 0.03f;
 
                 //remove transform so it goes to world
-                effect.parent = null;
+                prefabContainer.parent = null;
                 // loop lerp
                 for (int i = 0; i < 10; i++)
                 {
                     await UniTask.WaitForSeconds(delay, cancellationToken: token);
-                    effect.position = Vector3.Lerp(effect.position, dest.position, 0.45f);
+                    prefabContainer.position = Vector3.Lerp(prefabContainer.position, dest.position, 0.45f);
                 }
                 // add new transform of hand
-                effect.parent = dest;
-                effect.localPosition = Vector3.zero;
+                prefabContainer.parent = dest;
+                prefabContainer.localPosition = Vector3.zero;
 
                 //if last gesture was earth, stop the vfx (so the touch spell works)
                 if (_lastGesture != null && _lastGesture._rightHandShape == HandShape.Earth)
@@ -252,8 +228,19 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
         internal void DisableHandVFX(HandData hand)
         {
-            if (hand._currentEffect != null)
-                hand._currentEffect.Stop();
+            if (hand == _handDataRight)
+            {
+                _visualEffectRight.transform.parent = null;
+                _objectPooler.ReturnObject(_visualEffectRight.name, _visualEffectRight);
+            }
+            else
+            {
+                _visualEffectLeft.transform.parent = null;
+                _objectPooler.ReturnObject(_visualEffectLeft.name, _visualEffectLeft);
+            }
+
+            if (hand._prefabContainer != null)
+                hand._prefabContainer.SetActive(false);
         }
 
         internal async UniTask ChargeEffect(HandData handData, float delay)
@@ -273,21 +260,29 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 
         private void DisableBothHandEffects()
         {
-            if (_handDataRight._currentEffect != null)
-                _handDataRight._currentEffect.Stop();
-            if (_handDataLeft._currentEffect != null)
-                _handDataLeft._currentEffect.Stop();
+            if (_visualEffectRight != null && _visualEffectRight.activeSelf)
+            {
+                _visualEffectRight.transform.parent = null;
+                _objectPooler.ReturnObject(_visualEffectRight.name, _visualEffectRight);
+                _handDataRight._prefabContainer.SetActive(false);
+            }
+            if (_visualEffectLeft != null && _visualEffectLeft.activeSelf)
+            {
+                _visualEffectLeft.transform.parent = null;
+                _objectPooler.ReturnObject(_visualEffectLeft.name, _visualEffectLeft);
+                _handDataLeft._prefabContainer.SetActive(false);
+            }
         }
 
-        private async void DestroyVisualEffectWhenDone(CancellationToken token, GameObject effect)
+        private async void ReturnVisualEffect(CancellationToken token, GameObject effect)
         {
             try
             {
                 if (effect.TryGetComponent<VisualEffect>(out VisualEffect visual))
                 {
-                    // Destroy effect after it is done playing.
                     await UniTask.WaitUntil(() => visual.aliveParticleCount == 0, cancellationToken: token);
-                    Destroy(effect);
+                    effect.transform.parent = null;
+                    _objectPooler.ReturnObject(effect.name, effect);
                 }
             }
             catch (OperationCanceledException)

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
@@ -29,14 +29,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
             //sub to the gesture recognized and spell recognized events
             SpellManager.onSpellValidation += HandleSpellRecognized;
             SpellManager.onNoSpellMatch += HandleSpellFailed;
-            _sequenceManager.OnGestureRecognised += HandleGestureRecognized;
+            _sequenceManager.onGestureRecognised += HandleGestureRecognized;
         }
         private void OnDestroy()
         {
             //unsubscribe
             SpellManager.onSpellValidation -= HandleSpellRecognized;
             SpellManager.onNoSpellMatch -= HandleSpellFailed;
-            _sequenceManager.OnGestureRecognised -= HandleGestureRecognized;
+            _sequenceManager.onGestureRecognised -= HandleGestureRecognized;
         }
 
         void HandleGestureRecognized(List<Gesture> gesture)

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
@@ -1,4 +1,5 @@
 using RogueApeStudios.SecretsOfIgnacios.Gestures;
+using RogueApeStudios.SecretsOfIgnacios.Services;
 using RogueApeStudios.SecretsOfIgnacios.Spells;
 using System.Collections.Generic;
 using UnityEngine;
@@ -16,63 +17,71 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
             -On an element added, change the colour to the element's colour - make it a gradient if possible
             -On end cast sign, set should be alive to false
          */
+        [SerializeField] private ObjectPooler _objectPooler;
 
         [SerializeField] private VisualEffect _magicCircle;
         [SerializeField] private GameObject _propertyControls;
         [SerializeField] private LineRenderer _colorControls;
         [SerializeField] private SequenceManager _sequenceManager;
 
+        private GameObject _pooledObject;
+
         private void Start()
         {
             _magicCircle.Stop();
 
             //sub to the gesture recognized and spell recognized events
-            SpellManager.onSpellValidation += HandleSpellRecognized;
-            SpellManager.onNoSpellMatch += HandleSpellFailed;
+            SpellManager.onSpellValidation += ResetMagicCircle;
+            SpellManager.onNoSpellMatch += ResetMagicCircle;
             _sequenceManager.onGestureRecognised += HandleGestureRecognized;
         }
         private void OnDestroy()
         {
             //unsubscribe
-            SpellManager.onSpellValidation -= HandleSpellRecognized;
-            SpellManager.onNoSpellMatch -= HandleSpellFailed;
+            SpellManager.onSpellValidation -= ResetMagicCircle;
+            SpellManager.onNoSpellMatch -= ResetMagicCircle;
             _sequenceManager.onGestureRecognised -= HandleGestureRecognized;
         }
 
-        void HandleGestureRecognized(List<Gesture> gesture)
+        void HandleGestureRecognized(List<Gesture> gestures)
         {
-            if (gesture.Count > 0)
+            if (gestures.Count > 0)
             {
-                switch (gesture[^1]._rightHandShape)
+                switch (gestures[^1]._rightHandShape)
                 {
                     case HandShape.Start:
+                        if (_pooledObject != null && _pooledObject.activeSelf)
+                        {
+                            _pooledObject.transform.parent = null;
+                            _objectPooler.ReturnObject(_pooledObject.name, _pooledObject);
+                        }
+
                         _propertyControls.SetActive(true);
                         _magicCircle.Play();
                         break;
-                    case HandShape.Fire:
-                        break;
-                    case HandShape.Water:
-                        break;
-                    case HandShape.Earth:
-                        break;
-                    case HandShape.Air:
-                        break;
                     default:
+                        if (gestures[^1]._visualEffectPrefab != null)
+                        {
+                            _objectPooler.CreatePool(gestures[^1]._visualEffectPrefab.name, gestures[^1]._visualEffectPrefab, 3);
+                            _pooledObject = _objectPooler.GetObject(gestures[^1]._visualEffectPrefab.name,
+                                gestures[^1]._visualEffectPrefab,
+                                transform);
+                            _pooledObject.transform.parent = transform;
+                        }
                         break;
                 }
-                _colorControls.startColor = gesture[^1]._color;
+                _colorControls.startColor = gestures[^1]._color;
             }
         }
 
-        void HandleSpellRecognized(bool recognized)
-        {
-            _propertyControls.SetActive(!recognized);
-        }
-
-        private void HandleSpellFailed()
+        private void ResetMagicCircle()
         {
             _propertyControls.SetActive(false);
+            if (_pooledObject != null)
+            {
+                _pooledObject.transform.parent = null;
+                _objectPooler.ReturnObject(_pooledObject.name, _pooledObject);
+            }
         }
-
     }
 }

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.VFX;
 
-namespace RogueApeStudios.SecretsOfIgnacios.Player
+namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 {
     public class MagicCirclePlayerFeedback : MonoBehaviour
     {
@@ -18,7 +18,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
          */
 
         [SerializeField] private VisualEffect _magicCircle;
-        [SerializeField] private GameObject _boolControls;
+        [SerializeField] private GameObject _propertyControls;
         [SerializeField] private LineRenderer _colorControls;
         [SerializeField] private SequenceManager _sequenceManager;
 
@@ -46,7 +46,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
                 switch (gesture[^1]._rightHandShape)
                 {
                     case HandShape.Start:
-                        _boolControls.SetActive(true);
+                        _propertyControls.SetActive(true);
                         _magicCircle.Play();
                         break;
                     case HandShape.Fire:
@@ -66,12 +66,12 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
 
         void HandleSpellRecognized(bool recognized)
         {
-            _boolControls.SetActive(false);
+            _propertyControls.SetActive(!recognized);
         }
 
         private void HandleSpellFailed()
         {
-            _boolControls.SetActive(false);
+            _propertyControls.SetActive(false);
         }
 
     }

--- a/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePosition.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/MagicCirclePosition.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace RogueApeStudios.SecretsOfIgnacios.Player
+namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 {
     public class MagicCirclePosition : MonoBehaviour
     {
@@ -9,23 +9,19 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
         [SerializeField] List<Transform> _handpositions;
         [SerializeField] float _aheadValue = 0f;
         [SerializeField] float _upValue = 0f;
-        // Start is called once before the first execution of Update after the MonoBehaviour is created
-        void Start()
-        {
-        
-        }
 
-        // Update is called once per frame
         void FixedUpdate()
         {
-
             //get rotation between the two hands, not accounting for height
-            Vector3 dirvector = Quaternion.AngleAxis(-90, Vector3.up) *  new Vector3(_handpositions[0].position.x - _handpositions[1].position.x, 0, _handpositions[0].position.z - _handpositions[1].position.z).normalized; 
-            //lerp rotation between last rotation and now (smoothes the process)
-            transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(dirvector), 0.5f);
-            //lerp position between last position and now (smoothes the process)
-            transform.position = Vector3.Lerp(transform.position, (_handpositions[0].position + _handpositions[1].position)/2 + dirvector * _aheadValue + Vector3.up * _upValue,0.5f);
+            Vector3 dirvector = Quaternion.AngleAxis(-90,
+                Vector3.up) * new Vector3(_handpositions[0].position.x - _handpositions[1].position.x,
+                0, _handpositions[0].position.z - _handpositions[1].position.z).normalized;
 
+            //lerp rotation between last rotation and now (smoothes the process)
+            //lerp position between last position and now (smoothes the process)
+            transform.SetPositionAndRotation(Vector3.Lerp(transform.position,
+                (_handpositions[0].position + _handpositions[1].position) / 2 + dirvector * _aheadValue + Vector3.up * _upValue, 0.5f),
+                Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(dirvector), 0.5f));
         }
     }
 }

--- a/Assets/Scripts/Player/SpellMagicCircle/VFXBinderColourProperty.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/VFXBinderColourProperty.cs
@@ -2,34 +2,37 @@ using UnityEngine;
 using UnityEngine.VFX;
 using UnityEngine.VFX.Utility;
 
-// The VFXBinder Attribute will populate this class into the property binding's add menu.
-/// <summary>
-/// This was taken and adapted from the Unity official documentation.
-/// </summary>
-[VFXBinder("Material/Colour")]
-// The class needs to extend VFXBinderBase
-public class VFXBinderColourProperty : VFXBinderBase
+namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 {
-    // VFXPropertyBinding attributes enables the use of a specific
-    // property drawer that populates the VisualEffect properties of a
-    // certain type.
-    [VFXPropertyBinding("System.Single")]
-    public ExposedProperty _colorProperty;
-
-    public LineRenderer target;
-
-    // The IsValid method need to perform the checks and return if the binding
-    // can be achieved.
-    public override bool IsValid(VisualEffect component)
+    // The VFXBinder Attribute will populate this class into the property binding's add menu.
+    /// <summary>
+    /// This was taken and adapted from the Unity official documentation.
+    /// </summary>
+    [VFXBinder("Material/Colour")]
+    // The class needs to extend VFXBinderBase
+    public class VFXBinderColourProperty : VFXBinderBase
     {
-        return target != null && component.HasVector4(_colorProperty);
-    }
+        // VFXPropertyBinding attributes enables the use of a specific
+        // property drawer that populates the VisualEffect properties of a
+        // certain type.
+        [VFXPropertyBinding("System.Single")]
+        public ExposedProperty _colorProperty;
 
-    // The UpdateBinding method is the place where you perform the binding,
-    // by assuming that it is valid. This method will be called only if
-    // IsValid returned true.
-    public override void UpdateBinding(VisualEffect component)
-    {
-        component.SetVector4(_colorProperty, target.startColor);
+        public LineRenderer target;
+
+        // The IsValid method need to perform the checks and return if the binding
+        // can be achieved.
+        public override bool IsValid(VisualEffect component)
+        {
+            return target != null && component.HasVector4(_colorProperty);
+        }
+
+        // The UpdateBinding method is the place where you perform the binding,
+        // by assuming that it is valid. This method will be called only if
+        // IsValid returned true.
+        public override void UpdateBinding(VisualEffect component)
+        {
+            component.SetVector4(_colorProperty, target.startColor);
+        }
     }
 }

--- a/Assets/Scripts/Services/ObjectPooler.cs
+++ b/Assets/Scripts/Services/ObjectPooler.cs
@@ -36,12 +36,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Services
 
         }
 
-        private void CreatePool(string objectType, GameObject prefab, int initialSize)
+        public void CreatePool(string objectType, GameObject prefab, int initialSize)
         {
-            string poolKey = objectType + "(Clone)";
+            string poolKey = objectType.Replace("(Clone)", "").Trim();
 
-            if (!_objectPools.ContainsKey(poolKey))
-                _objectPools[poolKey] = new();
+            if (_objectPools.ContainsKey(poolKey))
+                return;
+
+            _objectPools[poolKey] = new();
 
             int currentCount = _objectPools[poolKey].Count;
             int itemsToAdd = initialSize - currentCount;
@@ -54,10 +56,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Services
             }
         }
 
-        public GameObject GetObject(string objectType, GameObject prefab, Transform transform)
+        public GameObject GetObject(string poolKey, GameObject prefab, Transform transform)
         {
-            string poolKey = objectType + "(Clone)";
-
             if (!_objectPools.ContainsKey(poolKey))
             {
                 Debug.LogError($"No pool exists for this object type: {poolKey}");
@@ -81,15 +81,17 @@ namespace RogueApeStudios.SecretsOfIgnacios.Services
 
         public void ReturnObject(string objectType, GameObject obj)
         {
-            if (!_objectPools.ContainsKey(objectType))
+            string poolKey = objectType.Replace("(Clone)", "").Trim();
+
+            if (!_objectPools.ContainsKey(poolKey))
             {
-                Debug.LogError($"No pool exists for object type: {objectType}");
+                Debug.LogError($"No pool exists for object type: {poolKey}");
                 return;
             }
 
             obj.SetActive(false);
             obj.transform.position = _poolParent.position;
-            _objectPools[objectType].Enqueue(obj);
+            _objectPools[poolKey].Enqueue(obj);
         }
     }
 }

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -121,7 +121,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 handData._renderer.materials[1].SetColor("_MainColor", handData._defaultColor);
                 handData._renderer.material = handData._defaultMaterial;
 
-
                 _handVfxManager.DisableHandVFX(handData);
             }
         }

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.VFX;
-using UnityEngine.XR.Hands;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Spells
 {
@@ -23,7 +22,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private CancellationTokenSource _cancellationTokenSource;
         private Material _defaultMaterial;
 
-        internal event Action<Handedness> onSpellCastComplete;
+        internal event Action<HandData> onSpellCastComplete;
 
         private void Awake()
         {
@@ -153,9 +152,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             if (handData == null) return;
 
-            Handedness handIdentifier = handData == _leftHandData ? Handedness.Left : Handedness.Right;
-
-            onSpellCastComplete?.Invoke(handIdentifier);
+            onSpellCastComplete?.Invoke(handData);
         }
 
         private void HandleSpellValidation(bool canCast)

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -126,10 +126,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             }
         }
 
-        private void HandleSpellValidation(bool canCast)
+        private void HandleSpellValidation()
         {
-            _rightHandData._canCast = canCast;
-            _leftHandData._canCast = canCast;
+            _rightHandData._canCast = true;
+            _leftHandData._canCast = true;
         }
 
         public void CastNoHands(Transform transform, string objectType, GameObject spellPrefab)
@@ -137,35 +137,5 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             GameObject projectile = _pooler.GetObject(objectType, spellPrefab, transform);
             projectile.transform.SetPositionAndRotation(transform.position, transform.localRotation);
         }
-
-        //[Serializable]
-        //internal class HandData
-        //{
-        //    [Header("References")]
-        //    [SerializeField] internal Transform _handTransform;
-
-        //    [Header("Visual")]
-        //    [SerializeField] internal VisualEffect _chargeEffect;
-        //    [SerializeField] internal LineRenderer _lineRenderer;
-        //    [SerializeField] internal Renderer _renderer;
-        //    [SerializeField] internal Material _material;
-
-        //    internal Transform _spellPrefab;
-        //    internal bool _canCast = false;
-        //    internal bool _isCasting = false;
-
-        //    internal HandConfig GetHandConfig(SpellManager spellManager, bool isRightHand)
-        //    {
-        //        if (!spellManager.CurrentSpell._duoSpell)
-        //            return spellManager.CurrentSpell._primaryConfig;
-        //        else
-        //        {
-        //            if (isRightHand)
-        //                return spellManager.CurrentSpell._primaryConfig;
-        //            else
-        //                return spellManager.CurrentSpell._secondaryConfig;
-        //        }
-        //    }
-        //}
     }
 }

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -1,9 +1,10 @@
 using Cysharp.Threading.Tasks;
+using RogueApeStudios.SecretsOfIgnacios.Player;
+using RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle;
 using RogueApeStudios.SecretsOfIgnacios.Services;
 using System;
 using System.Threading;
 using UnityEngine;
-using UnityEngine.VFX;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Spells
 {
@@ -14,29 +15,18 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [SerializeField] private ObjectPooler _pooler;
         [SerializeField] internal HandData _rightHandData;
         [SerializeField] internal HandData _leftHandData;
+        [SerializeField] private HandVfxManager _handVfxManager;
 
         [Header("Casting Mode")]
-        [SerializeField] private bool _timerAim = true;
         [SerializeField] private float _castTimer = 0.75f;
 
         private CancellationTokenSource _cancellationTokenSource;
-        private Material _defaultMaterial;
-
-        internal event Action<HandData> onSpellCastComplete;
 
         private void Awake()
         {
             SpellManager.onSpellValidation += HandleSpellValidation;
 
             _cancellationTokenSource = new CancellationTokenSource();
-        }
-
-        private void Start()
-        {
-            _rightHandData._chargeEffect.Stop();
-            _leftHandData._chargeEffect.Stop();
-
-            _defaultMaterial = _rightHandData._material;
         }
 
         private void OnDestroy()
@@ -61,7 +51,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                     HandConfig config = handData.GetHandConfig(_spellManager, handData == _rightHandData);
 
                     if (config._castType == CastTypes.Charged)
-                        await ChargeEffect(handData);
+                        await _handVfxManager.ChargeEffect(handData, _castTimer);
 
                     ExecuteSpell(handData, config._castType);
                 }
@@ -70,19 +60,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             {
                 Debug.LogError("Spell casting was canceled");
             }
-        }
-
-        private async UniTask ChargeEffect(HandData handData)
-        {
-            if (_timerAim && handData._canCast)
-            {
-                handData._lineRenderer.enabled = true;
-                handData._chargeEffect.Play();
-                await UniTask.WaitForSeconds(_castTimer, cancellationToken: _cancellationTokenSource.Token);
-                handData._lineRenderer.enabled = false;
-            }
-            else
-                handData._lineRenderer.enabled = false;
         }
 
         private void ExecuteSpell(HandData handData, CastTypes castType)
@@ -105,11 +82,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private void SingleCast(HandData handData)
         {
             GetSpellProjectile(handData);
-            handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
-            handData._renderer.material = _defaultMaterial;
+            handData._renderer.materials[1].SetColor("_MainColor", handData._defaultColor);
+            handData._renderer.material = handData._defaultMaterial;
             handData._canCast = false;
 
-            RemoveVFXFromHand(handData);
+            _handVfxManager.DisableHandVFX(handData);
         }
 
         private async void RepeatedCast(HandData handData)
@@ -126,11 +103,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             HandConfig spell = handData.GetHandConfig(_spellManager, handData == _rightHandData);
 
-            GameObject obj = _pooler.GetObject(spell._spellPrefab.name, spell._spellPrefab, handData._handTransform);
+            GameObject obj = _pooler.GetObject(spell._spellPrefab.name, spell._spellPrefab, handData._spellSpawnPoint);
 
-            if (spell._castType == CastTypes.Touch)
+            if (spell._castType is CastTypes.Touch)
             {
-                obj.transform.SetParent(handData._handTransform, false);
+                obj.transform.SetParent(handData._spellSpawnPoint, false);
                 obj.transform.SetLocalPositionAndRotation(spell._position, new(0, 0, 0, 0));
             }
         }
@@ -141,18 +118,12 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             {
                 handData._isCasting = false;
                 handData._canCast = false;
-                handData._renderer.materials[1].SetColor("_MainColor", _spellManager.DefaultColor);
-                handData._renderer.material = _defaultMaterial;
+                handData._renderer.materials[1].SetColor("_MainColor", handData._defaultColor);
+                handData._renderer.material = handData._defaultMaterial;
 
-                RemoveVFXFromHand(handData);
+
+                _handVfxManager.DisableHandVFX(handData);
             }
-        }
-
-        private void RemoveVFXFromHand(HandData handData)
-        {
-            if (handData == null) return;
-
-            onSpellCastComplete?.Invoke(handData);
         }
 
         private void HandleSpellValidation(bool canCast)
@@ -167,34 +138,34 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             projectile.transform.SetPositionAndRotation(transform.position, transform.localRotation);
         }
 
-        [Serializable]
-        internal class HandData
-        {
-            [Header("References")]
-            [SerializeField] internal Transform _handTransform;
+        //[Serializable]
+        //internal class HandData
+        //{
+        //    [Header("References")]
+        //    [SerializeField] internal Transform _handTransform;
 
-            [Header("Visual")]
-            [SerializeField] internal VisualEffect _chargeEffect;
-            [SerializeField] internal LineRenderer _lineRenderer;
-            [SerializeField] internal Renderer _renderer;
-            [SerializeField] internal Material _material;
+        //    [Header("Visual")]
+        //    [SerializeField] internal VisualEffect _chargeEffect;
+        //    [SerializeField] internal LineRenderer _lineRenderer;
+        //    [SerializeField] internal Renderer _renderer;
+        //    [SerializeField] internal Material _material;
 
-            internal Transform _spellPrefab;
-            internal bool _canCast = false;
-            internal bool _isCasting = false;
+        //    internal Transform _spellPrefab;
+        //    internal bool _canCast = false;
+        //    internal bool _isCasting = false;
 
-            internal HandConfig GetHandConfig(SpellManager spellManager, bool isRightHand)
-            {
-                if (!spellManager.CurrentSpell._duoSpell)
-                    return spellManager.CurrentSpell._primaryConfig;
-                else
-                {
-                    if (isRightHand)
-                        return spellManager.CurrentSpell._primaryConfig;
-                    else
-                        return spellManager.CurrentSpell._secondaryConfig;
-                }
-            }
-        }
+        //    internal HandConfig GetHandConfig(SpellManager spellManager, bool isRightHand)
+        //    {
+        //        if (!spellManager.CurrentSpell._duoSpell)
+        //            return spellManager.CurrentSpell._primaryConfig;
+        //        else
+        //        {
+        //            if (isRightHand)
+        //                return spellManager.CurrentSpell._primaryConfig;
+        //            else
+        //                return spellManager.CurrentSpell._secondaryConfig;
+        //        }
+        //    }
+        //}
     }
 }

--- a/Assets/Scripts/Spells/Indicator.cs
+++ b/Assets/Scripts/Spells/Indicator.cs
@@ -20,11 +20,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private void FixedUpdate()
         {
             if (_cast._rightHandData._lineRenderer.enabled)
-                UpdateBeam(_cast._rightHandData._lineRenderer, _cast._rightHandData._handTransform,
+                UpdateBeam(_cast._rightHandData._lineRenderer, _cast._rightHandData._spellSpawnPoint,
                     ref _rightIsGrowing, ref _rightCurrentLength);
 
             if (_cast._leftHandData._lineRenderer.enabled)
-                UpdateBeam(_cast._leftHandData._lineRenderer, _cast._leftHandData._handTransform,
+                UpdateBeam(_cast._leftHandData._lineRenderer, _cast._leftHandData._spellSpawnPoint,
                     ref _leftIsGrowing, ref _leftCurrentLength);
         }
 

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -15,9 +15,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [SerializeField] private SequenceManager _sequenceManager;
         [SerializeField] private ServiceLocator _serviceLocator;
         [SerializeField] private HandVfxManager _handVfxManager;
-        [Header("Hand Objects")]
-        [SerializeField] private Renderer _rightHandMaterial;
-        [SerializeField] private Renderer _leftHandMaterial;
 
         [Header("Spells")]
         [SerializeField] private Spell[] _availableSpells;

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -27,6 +27,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private CancellationTokenSource _cancellationTokenSource;
 
         public static event Action onSpellValidation;
+        public static event Action onQuickCastValidation;
         public static event Action onNoSpellMatch;
 
         internal Spell CurrentSpell => _currentSpell;
@@ -136,15 +137,14 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         internal void HandleReset()
         {
             _currentSpell = null;
-
             _handVfxManager.ResetHandColors();
         }
 
         private void HandleOnQuickCast()
         {
             _currentSpell = _lastSpell;
-
             _handVfxManager.SetHandEffects(_currentSpell, true);
+            onQuickCastValidation?.Invoke();
             onSpellValidation?.Invoke();
         }
 

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -49,6 +49,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _sequenceManager.onGestureRecognised -= CheckSequence;
             _sequenceManager.onReset -= HandleReset;
+            _sequenceManager.onQuickCast -= HandleOnQuickCast;
             ProgressionManager.OnProgressionEvent += HandleProgressionEvent;
 
             _cancellationTokenSource.Cancel();
@@ -71,12 +72,13 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             if (exactMatch != null && exactMatch._isUnlocked)
             {
                 SetSpell(exactMatch);
-                _handVfxManager.HandleCastRecognized(true);
+                onSpellValidation?.Invoke(exactMatch);
             }
             else if (!hasPartialMatch)
             {
                 _currentSpell = null;
                 _handVfxManager.HandleOnSpellFailed();
+                onNoSpellMatch?.Invoke();
             }
             // If there is a partial match, do nothing and wait for more gestures.
         }
@@ -127,7 +129,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _currentSpell = spell;
             _lastSpell = spell;
-            _handVfxManager.SetHandEffects(true, _currentSpell);
+            _handVfxManager.SetHandEffects(true, _currentSpell, false);
         }
 
 
@@ -135,16 +137,15 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _currentSpell = null;
 
-            _handVfxManager.SetHandEffects(false, _currentSpell);
-            _handVfxManager.HandleCastRecognized(false);
+            _handVfxManager.SetHandEffects(false, _currentSpell, false);
         }
 
         private void HandleOnQuickCast()
         {
             _currentSpell = _lastSpell;
 
-            _handVfxManager.SetHandEffects(true, _currentSpell);
-            _handVfxManager.HandleCastRecognized(true);
+            _handVfxManager.SetHandEffects(true, _currentSpell, true);
+            onSpellValidation?.Invoke(true);
         }
 
         private void UnlockSpell(Spell spell)

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -26,7 +26,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         private Spell _lastSpell;
         private CancellationTokenSource _cancellationTokenSource;
 
-        public static event Action<bool> onSpellValidation;
+        public static event Action onSpellValidation;
         public static event Action onNoSpellMatch;
 
         internal Spell CurrentSpell => _currentSpell;
@@ -72,7 +72,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
             if (exactMatch != null && exactMatch._isUnlocked)
             {
                 SetSpell(exactMatch);
-                onSpellValidation?.Invoke(exactMatch);
+                onSpellValidation?.Invoke();
             }
             else if (!hasPartialMatch)
             {
@@ -129,7 +129,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _currentSpell = spell;
             _lastSpell = spell;
-            _handVfxManager.SetHandEffects(true, _currentSpell, false);
+            _handVfxManager.SetHandEffects(_currentSpell, false);
         }
 
 
@@ -137,15 +137,15 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             _currentSpell = null;
 
-            _handVfxManager.SetHandEffects(false, _currentSpell, false);
+            _handVfxManager.ResetHandColors();
         }
 
         private void HandleOnQuickCast()
         {
             _currentSpell = _lastSpell;
 
-            _handVfxManager.SetHandEffects(true, _currentSpell, true);
-            onSpellValidation?.Invoke(true);
+            _handVfxManager.SetHandEffects(_currentSpell, true);
+            onSpellValidation?.Invoke();
         }
 
         private void UnlockSpell(Spell spell)


### PR DESCRIPTION
## Content

Put all hand vfx logic in the hand vfx manager and magic circle vfx in the magic circle vfx. It now also makes use of the object pooler, so vfx don't need to be instantiated and destroyed every time you cast your spells. Quick cast now actually works correctly with the vfx. Small bug with the palm up sign, if you have done the water spell before, when doing either the wind or fire spell, when the last sign is performed your hands will turn blue and not have any vfx (should be fixed when new signs are introduced).

## Changes
### Added
`Assets/Scripts/Player/HandData.cs` : Was created. It no longer is a nested class.

### Updated
`.gitignore` : Was updated / renamed. Added the font to git ignore (I think the font doesn't give a shit though).
`Assets/Scripts/Gestures/SequenceManager.cs` : Was updated / renamed. Removed color logic.
`Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs` : Was updated / renamed. Completely refactored.
`Assets/Scripts/Player/SpellMagicCircle/MagicCirclePlayerFeedback.cs` : Was updated / renamed. Now fully manages the magic circle's vfx.
`Assets/Scripts/Player/SpellMagicCircle/MagicCirclePosition.cs` : Was updated / renamed. Code cleanup and add correct namespace.
`Assets/Scripts/Player/SpellMagicCircle/VFXBinderColourProperty.cs` : Was updated / renamed. Added correct namespace and auto format.
`Assets/Scripts/Services/ObjectPooler.cs` : Was updated / renamed. Removes "(Clone)" from a object name if it has it and can create pools from other scripts (became a public void).
`Assets/Scripts/Spells/Cast.cs` : Was updated / renamed. Removed vfx logic.
`Assets/Scripts/Spells/Indicator.cs` : Was updated / renamed. Victim of a renamed field.
`Assets/Scripts/Spells/SpellManager.cs` : Was updated / renamed. Removed vfx logic.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Left and right hand in camera offset need hand data
2. Drag in references as in the image for both hands
![test](https://github.com/user-attachments/assets/bcb77fb6-4080-4add-a372-d7ccc56128af)
3. On the cast, spell manager and sequence manager scripts, drag in the necessary script references
4. Do the same on the hand vfx manager object in the player prefab
5. Cast spells in as many different ways as possible (normal, quick cast, shoot 1 hand then quick cast, quick cast when both hands are still active, start a new sequence when both or 1 hand is active, etc.)
6. If a reference is missing and you cant figure it out ping me

Closes #220 
