### PR TITLE
🐛 Water gate not opening

### DIFF
--- a/Assets/Scripts/Puzzle/WaterRoom/WaterTorchPuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/WaterRoom/WaterTorchPuzzleCheck.cs
@@ -6,42 +6,35 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
 {
     public class WaterTorchPuzzleCheck : MonoBehaviour
     {
+        [Header("References")]
         [SerializeField] private List<PersistentFire> _torches;
         [SerializeField] private Animator _animator;
+
+        [Header("Values")]
+        [SerializeField] private int _torchAmount = 2;
 
         private void Awake()
         {
 
             foreach (var torch in _torches)
-            {
                 torch.OnIgnitionToggle += TorchCheck;
-            }
         }
 
         private void OnDestroy()
         {
             foreach (var torch in _torches)
-            {
                 torch.OnIgnitionToggle -= TorchCheck;
-            }
         }
 
         private void TorchCheck(bool onFire)
         {
             int count = 0;
             foreach (var torch in _torches)
-            {
                 if (!torch._isOnFire)
-                {
                     count++;
-                }
-            }
 
-            if (count == 3)
-            {
-                Debug.Log("Door opens");
-                _animator.SetTrigger("DubbleIn");
-            }
+            if (count == _torchAmount)
+                _animator.SetTrigger("GateOpen");
         }
     }
 }


### PR DESCRIPTION
## Content

Water gate now opens when you douse the torches, the amount is now also modular.

## Changes

### Updated
`Assets/Scripts/Puzzle/WaterRoom/WaterTorchPuzzleCheck.cs` : Was updated / renamed. Correct amount and correct animation trigger.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Play in main level (no need for vr)
2. Drag in 2 water spell prefabs while game is paused
3. Position them in front of the torches, turn on kinematic on their rigid bodies and gravity off (just in case)
4. drag them int the torches when game is unpaused 

Closes #198 
