### PR TITLE
✨ area progression

### DIFF
--- a/Assets/Materials/Dungeon_Mat_White_Lamp.mat
+++ b/Assets/Materials/Dungeon_Mat_White_Lamp.mat
@@ -65,7 +65,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 827192daae941cb46a9d5bb8278c74e2, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Packs/PolygonDungeon/Prefabs/Environments/Walls/SM_Env_Door_02.prefab
+++ b/Assets/Packs/PolygonDungeon/Prefabs/Environments/Walls/SM_Env_Door_02.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2358248}
   - component: {fileID: 65325328118684746}
   - component: {fileID: 8892023987030495180}
+  - component: {fileID: 3576164486991658554}
   m_Layer: 0
   m_Name: SM_Env_Door_02
   m_TagString: Untagged
@@ -133,6 +134,19 @@ MonoBehaviour:
   _destructionEffect: {fileID: 6173544389828443239}
   _spawnObjectOnBurnt: 0
   _containedObjects: []
+--- !u!114 &3576164486991658554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 128464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94a9586f4ab4f3a4db9d11244073f5be, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _areaToUnlock: {fileID: 0}
 --- !u!1001 &468185461460169187
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Progression/ProgressionManager.prefab
+++ b/Assets/Prefabs/Progression/ProgressionManager.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9140701645158613004}
   - component: {fileID: 5538510372288205628}
+  - component: {fileID: 4913583215736520180}
   m_Layer: 0
   m_Name: ProgressionManager
   m_TagString: Untagged
@@ -42,5 +43,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8711ba493cd9a9444aed53b0c54ae573, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4913583215736520180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 488329634189106181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5079d17e57564457930991acaa5813a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Scripts/Progression/AreaProgression.meta
+++ b/Assets/Scripts/Progression/AreaProgression.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b0eb3ac4440d4cb9b0753ab4f895a9f1
+timeCreated: 1733746848

--- a/Assets/Scripts/Progression/AreaProgression/AreaProgressionManager.cs
+++ b/Assets/Scripts/Progression/AreaProgression/AreaProgressionManager.cs
@@ -1,0 +1,29 @@
+﻿using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Progression.AreaProgression
+{
+    public class AreaProgressionManager : MonoBehaviour
+    {
+        private void OnEnable()
+        {
+            ProgressionManager.OnProgressionEvent += HandleProgressionEvent;
+        }
+
+        private void OnDisable()
+        {
+            ProgressionManager.OnProgressionEvent -= HandleProgressionEvent;
+        }
+
+        private void HandleProgressionEvent(ProgressionData data)
+        {
+            if (data.Type == ProgressionType.AreaUnlock && data.Data is AreaUnlockData areaData)
+            {
+                if (areaData.Area != null)
+                {
+                    Debug.Log($"area {areaData.Area.name} has been unlocked");
+                    areaData.Area.SetActive(true);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Progression/AreaProgression/AreaProgressionManager.cs.meta
+++ b/Assets/Scripts/Progression/AreaProgression/AreaProgressionManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5079d17e57564457930991acaa5813a9
+timeCreated: 1733746857

--- a/Assets/Scripts/Progression/IProgressionData.cs
+++ b/Assets/Scripts/Progression/IProgressionData.cs
@@ -10,10 +10,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Progression
         public Spell Spell { get; set; }
     }
 
-    
-    //idk implement it
     public class AreaUnlockData : IProgressionData
     {
-        public GameObject AreaName { get; set; }
+        public GameObject Area { get; set; }
     }
 }
+  

--- a/Assets/Scripts/Progression/TestProgression.cs
+++ b/Assets/Scripts/Progression/TestProgression.cs
@@ -1,21 +1,22 @@
 using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Progression
 {
     public class TestProgression : MonoBehaviour
     {
-        [Header("Progression Type")] [SerializeField]
-        private ProgressionType _progressionType;
+        [Header("Progression Type")]
+        [SerializeField] private ProgressionType _progressionType;
 
-        [Header("Spell Unlock Data")] [SerializeField]
-        private Spell _spell;
+        [Header("Spell Unlock Data")]
+        [SerializeField] private List<Spell> _spells;
 
-        [Header("Area Unlock Data")] [SerializeField]
-        private GameObject _area; 
+        [Header("Area Unlock Data")]
+        [SerializeField] private List<GameObject> _areas;
 
-        [Header("Trigger Event")] [SerializeField]
-        private bool triggerEvent;
+        [Header("Trigger Event")]
+        [SerializeField] private bool triggerEvent;
 
         private void OnValidate()
         {
@@ -28,23 +29,52 @@ namespace RogueApeStudios.SecretsOfIgnacios.Progression
 
         private void TriggerProgressionEvent()
         {
-            ProgressionData data = new ProgressionData { Type = _progressionType };
-
             switch (_progressionType)
             {
                 case ProgressionType.SpellUnlock:
-                    if (_spell != null)
+                    if (_spells != null && _spells.Count > 0)
                     {
-                        data.Data = new SpellUnlockData { Spell = _spell };
+                        foreach (var spell in _spells)
+                        {
+                            if (spell != null)
+                            {
+                                ProgressionData data = new ProgressionData
+                                {
+                                    Type = ProgressionType.SpellUnlock,
+                                    Data = new SpellUnlockData { Spell = spell }
+                                };
+                                ProgressionManager.TriggerProgressionEvent(data);
+                            }
+                        }
                     }
                     else
                     {
-                        Debug.LogError("No spell set for SpellUnlock progression.");
+                        Debug.LogError("No spells assigned for SpellUnlock progression.");
+                    }
+                    break;
+
+                case ProgressionType.AreaUnlock:
+                    if (_areas != null && _areas.Count > 0)
+                    {
+                        foreach (var area in _areas)
+                        {
+                            if (area != null)
+                            {
+                                ProgressionData data = new ProgressionData
+                                {
+                                    Type = ProgressionType.AreaUnlock,
+                                    Data = new AreaUnlockData { Area = area }
+                                };
+                                ProgressionManager.TriggerProgressionEvent(data);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogError("No areas assigned for AreaUnlock progression.");
                     }
                     break;
             }
-
-            ProgressionManager.TriggerProgressionEvent(data);
         }
     }
 }

--- a/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
+++ b/Assets/Scripts/Puzzle/EarthRoom/EarthGateChecker.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Earth;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
@@ -8,6 +10,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
     {
         [SerializeField] private Resizable[] _resizableBlocks;
         [SerializeField] private Animator _animator;
+
+        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private void Awake()
         {
@@ -30,8 +34,11 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
         private void CheckGateStatus()
         {
             if (AreAllBlocksInState(ResizeState.Grown))
-                _animator.Play("BigGateOpen");
+            {
+                 _animator.Play("BigGateOpen");
                 Debug.Log("Open the gate");
+                UnlockAreas();   
+            }
         }
 
         private bool AreAllBlocksInState(ResizeState requiredState)
@@ -44,7 +51,26 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.EarthRoom
                     return false;
                 }
             }
+
             return true;
+        }
+
+        private void UnlockAreas()
+        {
+
+            foreach (var area in _areasToUnlock)
+            {
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Puzzle/FireRoom/BurnableDoorUnlock.cs
+++ b/Assets/Scripts/Puzzle/FireRoom/BurnableDoorUnlock.cs
@@ -1,0 +1,29 @@
+using RogueApeStudios.SecretsOfIgnacios.Progression;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
+{
+    public class BurnableDoorUnlock : MonoBehaviour
+    {
+        //Drag in teleport plane (not the parent object, but 1 of the planes, the one behind the door basically)
+        [SerializeField] private GameObject _areaToUnlock;
+
+        private void OnDestroy()
+        {
+            if (_areaToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.AreaUnlock,
+                    Data = new AreaUnlockData { Area = _areaToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
+            }
+            else
+            {
+                Debug.LogError("No area assigned to unlock");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Puzzle/FireRoom/BurnableDoorUnlock.cs.meta
+++ b/Assets/Scripts/Puzzle/FireRoom/BurnableDoorUnlock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94a9586f4ab4f3a4db9d11244073f5be

--- a/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
@@ -45,25 +45,23 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
 
-                if (_areasToUnlock != null && _areasToUnlock.Count > 0)
-                {
-                    foreach (var area in _areasToUnlock)
-                    {
-                        if (area != null)
-                        {
-                            ProgressionData progressionData = new ProgressionData
-                            {
-                                Type = ProgressionType.AreaUnlock,
-                                Data = new AreaUnlockData { Area = area }
-                            };
+                UnlockAreas();
+            }
+        }
 
-                            ProgressionManager.TriggerProgressionEvent(progressionData);
-                        }
-                        else
-                        {
-                            Debug.LogWarning("An area in the list is null and will be skipped.");
-                        }
-                    }
+        private void UnlockAreas()
+        {
+            foreach (var area in _areasToUnlock)
+            {
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
                 }
             }
         }

--- a/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
@@ -1,6 +1,7 @@
 using RogueApeStudios.SecretsOfIgnacios.Interactables;
 using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
@@ -9,6 +10,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
     {
         [SerializeField] private List<PersistentFire> _torches;
         [SerializeField] private Animator _animator;
+        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private void Awake()
         {
@@ -18,6 +20,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
                 torch.OnIgnitionToggle += TorchCheck;
             }
         }
+
         private void OnDestroy()
         {
             foreach (var torch in _torches)
@@ -25,6 +28,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
                 torch.OnIgnitionToggle -= TorchCheck;
             }
         }
+
         private void TorchCheck(bool onFire)
         {
             int count = 0;
@@ -40,6 +44,27 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
             {
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
+
+                if (_areasToUnlock != null && _areasToUnlock.Count > 0)
+                {
+                    foreach (var area in _areasToUnlock)
+                    {
+                        if (area != null)
+                        {
+                            ProgressionData progressionData = new ProgressionData
+                            {
+                                Type = ProgressionType.AreaUnlock,
+                                Data = new AreaUnlockData { Area = area }
+                            };
+
+                            ProgressionManager.TriggerProgressionEvent(progressionData);
+                        }
+                        else
+                        {
+                            Debug.LogWarning("An area in the list is null and will be skipped.");
+                        }
+                    }
+                }
             }
         }
     }

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
@@ -6,7 +7,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
     public class DragonDoorPuzzle : MonoBehaviour
     {
         [SerializeField] private Animator _animator;
-        [SerializeField] private GameObject _areaToUnlock;
+        [SerializeField] private List<GameObject> _areasToUnlock;
+
         private void OnTriggerEnter(Collider other)
         {
             if (other.gameObject.CompareTag("Potion"))
@@ -15,21 +17,25 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 gameObject.SetActive(false);
                 _animator.SetTrigger("DubbleIn");
                 
-                
-            if (_areaToUnlock != null)
-            {
-                ProgressionData progressionData = new ProgressionData
-                {
-                    Type = ProgressionType.AreaUnlock,
-                    Data = new AreaUnlockData { Area = _areaToUnlock }
-                };
-
-                ProgressionManager.TriggerProgressionEvent(progressionData);
+                UnlockAreas();
             }
-            else
+        }
+        
+        private void UnlockAreas()
+        {
+            foreach (var area in _areasToUnlock)
             {
-                Debug.LogError("No area assigned to unlock");
-            }            }
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
@@ -1,3 +1,4 @@
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
@@ -5,7 +6,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
     public class DragonDoorPuzzle : MonoBehaviour
     {
         [SerializeField] private Animator _animator;
-
+        [SerializeField] private GameObject _areaToUnlock;
         private void OnTriggerEnter(Collider other)
         {
             if (other.gameObject.CompareTag("Potion"))
@@ -13,7 +14,22 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 other.gameObject.SetActive(false);
                 gameObject.SetActive(false);
                 _animator.SetTrigger("DubbleIn");
+                
+                
+            if (_areaToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.AreaUnlock,
+                    Data = new AreaUnlockData { Area = _areaToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
             }
+            else
+            {
+                Debug.LogError("No area assigned to unlock");
+            }            }
         }
     }
 }

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
@@ -2,6 +2,7 @@ using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Wind;
 using System.Collections.Generic;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
@@ -16,6 +17,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 
         [SerializeField] private Animator _animator;
 
+        [SerializeField] private List<GameObject> _areasToUnlock;
+        
         private void Awake()
         {
             _waterTarget.onFilled += TargetCheck;
@@ -36,6 +39,24 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
             {
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
+                UnlockAreas();
+            }
+        }
+        
+        private void UnlockAreas()
+        {
+            foreach (var area in _areasToUnlock)
+            {
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
+                }
             }
         }
     }

--- a/Assets/Scripts/Puzzle/WaterRoom/GatePuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/WaterRoom/GatePuzzleCheck.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Earth;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
@@ -10,6 +11,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
         [SerializeField] private List<Fillable> _vases;
         [SerializeField] private List<Resizable> _resizableVases;
         [SerializeField] private Animator _animator;
+        
+        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private void Awake()
         {
@@ -64,6 +67,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
             {
                 Debug.Log("Gate opens");
                 _animator.SetTrigger("GateOpen");
+                UnlockAreas();
             }
         }
         
@@ -78,6 +82,23 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
             }
 
             return false;
+        }
+        
+        private void UnlockAreas()
+        {
+            foreach (var area in _areasToUnlock)
+            {
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Puzzle/WaterRoom/WaterTorchPuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/WaterRoom/WaterTorchPuzzleCheck.cs
@@ -1,5 +1,6 @@
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
 using System.Collections.Generic;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
@@ -8,6 +9,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
     {
         [SerializeField] private List<PersistentFire> _torches;
         [SerializeField] private Animator _animator;
+        
+        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private void Awake()
         {
@@ -41,6 +44,23 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WaterRoom
             {
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
+            }
+        }
+        
+        private void UnlockAreas()
+        {
+            foreach (var area in _areasToUnlock)
+            {
+                if (area != null)
+                {
+                    ProgressionData progressionData = new ProgressionData
+                    {
+                        Type = ProgressionType.AreaUnlock,
+                        Data = new AreaUnlockData { Area = area }
+                    };
+
+                    ProgressionManager.TriggerProgressionEvent(progressionData);
+                }
             }
         }
     }

--- a/Assets/Scripts/Puzzle/WindRoom/FanPuzzle.cs
+++ b/Assets/Scripts/Puzzle/WindRoom/FanPuzzle.cs
@@ -8,8 +8,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WindRoom
     {
         [SerializeField] private List<Spinnable> _fans;
         [SerializeField] private Animator _animator;
-        
-        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private int _previousCount = 0;
 

--- a/Assets/Scripts/Puzzle/WindRoom/FanPuzzle.cs
+++ b/Assets/Scripts/Puzzle/WindRoom/FanPuzzle.cs
@@ -8,6 +8,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.WindRoom
     {
         [SerializeField] private List<Spinnable> _fans;
         [SerializeField] private Animator _animator;
+        
+        [SerializeField] private List<GameObject> _areasToUnlock;
 
         private int _previousCount = 0;
 

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -68,10 +68,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
                 Debug.Log($"Spell '{spellData.Spell.name}' has been unlocked!");
                 UnlockSpell(spellData.Spell);
             }
-            else
-            {
-                Debug.LogError("Invalid data received for SpellUnlock event.");
-            }
         }
 
         public bool IsSpellUnlockedForGesture(Gesture gesture)


### PR DESCRIPTION
## Content
Each puzzle is now linked to an unlock areas. These areas can be a full teleportation area, or individual planes (necessary for some)

## Changes
### Added
`Assets/Scripts/Progression/AreaProgression/AreaProgressionManager.cs` : Was created
`Assets/Scripts/Puzzle/FireRoom/BurnableDoorUnlock.cs` : Was created

### Updated
`Assets/Packs/PolygonDungeon/Prefabs/Environments/Walls/SM_Env_Door_02.prefab` : Was updated to have the script of burnabledoor
`Assets/Prefabs/Progression/ProgressionManager.prefab` : Was updated to have the areaprogressionmanager
`Assets/Scripts/Progression/TestProgression.cs` : Was updated to house multiple areas/ spells
`Assets/Scripts/Progression/IProgressionData.cs` : Was updated with the new area type
`A lot of puzzle scripts` : Were updated to unlock puzzles

## Testing

The feature / Bugfix can be testing by following these steps:

1. Open main level
2. Drag in the progression prefabs
3. Unlock things
4. Keep in mind, these have to manually be selected in the level later on

Closes #178 
