### PR TITLE
✨ spell puzzle progression

### DIFF
--- a/Assets/Scripts/Puzzle/FireRoom/TilePuzzleSequenceChecker.cs
+++ b/Assets/Scripts/Puzzle/FireRoom/TilePuzzleSequenceChecker.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using RogueApeStudios.SecretsOfIgnacios.Progression;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
@@ -7,12 +9,15 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
     {
         [SerializeField] private List<GameObject> _tileSequence;
         private List<GameObject> _tileCollisions = new();
+        [SerializeField] private Spell _spellToUnlock;
 
         internal void AddAndValidate(GameObject tile)
         {
             AddTileToList(tile);
             if (_tileCollisions.Count == _tileSequence.Count)
             {
+                //Fire spell
+                UnlockSpell();
                 //victory
             }
             else
@@ -38,6 +43,20 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
                 //incorrect
                 Debug.Log("Faal");
                 _tileCollisions.Clear();
+            }
+        }
+        
+        private void UnlockSpell()
+        {
+           if (_spellToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.SpellUnlock,
+                    Data = new SpellUnlockData() { Spell = _spellToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
             }
         }
     }

--- a/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
+++ b/Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs
@@ -2,6 +2,7 @@ using RogueApeStudios.SecretsOfIgnacios.Interactables;
 using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
 using RogueApeStudios.SecretsOfIgnacios.Progression;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
@@ -11,7 +12,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
         [SerializeField] private List<PersistentFire> _torches;
         [SerializeField] private Animator _animator;
         [SerializeField] private List<GameObject> _areasToUnlock;
-
+        [SerializeField] private Spell _spellToUnlock;
+        
         private void Awake()
         {
 
@@ -46,6 +48,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
                 _animator.SetTrigger("DubbleIn");
 
                 UnlockAreas();
+                //Water spell
+                UnlockSpell();
             }
         }
 
@@ -63,6 +67,20 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.FireRoom
 
                     ProgressionManager.TriggerProgressionEvent(progressionData);
                 }
+            }
+        }
+        
+        private void UnlockSpell()
+        {
+           if (_spellToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.SpellUnlock,
+                    Data = new SpellUnlockData() { Spell = _spellToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
             }
         }
     }

--- a/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Progression;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
@@ -8,6 +9,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
     {
         [SerializeField] private Animator _animator;
         [SerializeField] private List<GameObject> _areasToUnlock;
+        [SerializeField] private Spell _spellToUnlock;
 
         private void OnTriggerEnter(Collider other)
         {
@@ -18,6 +20,8 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 _animator.SetTrigger("DubbleIn");
                 
                 UnlockAreas();
+                //Wind spell
+                UnlockSpell();
             }
         }
         
@@ -35,6 +39,20 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 
                     ProgressionManager.TriggerProgressionEvent(progressionData);
                 }
+            }
+        }
+
+        private void UnlockSpell()
+        {
+           if (_spellToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.SpellUnlock,
+                    Data = new SpellUnlockData() { Spell = _spellToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
             }
         }
     }

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
@@ -3,6 +3,7 @@ using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Wind;
 using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Progression;
+using RogueApeStudios.SecretsOfIgnacios.Spells;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
@@ -18,6 +19,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
         [SerializeField] private Animator _animator;
 
         [SerializeField] private List<GameObject> _areasToUnlock;
+        [SerializeField] private Spell _spellToUnlock;
         
         private void Awake()
         {
@@ -40,6 +42,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
                 UnlockAreas();
+                UnlockSpell();
             }
         }
         
@@ -59,5 +62,20 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 }
             }
         }
+        
+        private void UnlockSpell()
+        {
+           if (_spellToUnlock != null)
+            {
+                ProgressionData progressionData = new ProgressionData
+                {
+                    Type = ProgressionType.SpellUnlock,
+                    Data = new SpellUnlockData() { Spell = _spellToUnlock }
+                };
+
+                ProgressionManager.TriggerProgressionEvent(progressionData);
+            }
+        }
+        
     }
 }

--- a/Assets/Scripts/Spells/ScriptableObjects/Fire.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Fire.asset
@@ -38,3 +38,4 @@ MonoBehaviour:
     _handColor: {r: 0, g: 0, b: 0, a: 0}
     _poolSize: 0
     _chargeEffect: {fileID: 0}
+  _isUnlocked: 1

--- a/Assets/Scripts/Spells/SpellManager.cs
+++ b/Assets/Scripts/Spells/SpellManager.cs
@@ -58,7 +58,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         {
             if (data.Type == ProgressionType.SpellUnlock && data.Data is SpellUnlockData spellData)
                 UnlockSpell(spellData.Spell);
-            }
         }
 
         public bool IsSpellUnlockedForGesture(Gesture gesture)


### PR DESCRIPTION
## Content

Spells now unlock at corresponding puzzles

## Changes
### Updated
`Assets/Scripts/Spells/SpellManager.cs` : Was updated to not be broken, sorry

`Assets/Scripts/Spells/ScriptableObjects/Fire.asset` : Was updated to be unlocked by default
`Assets/Scripts/Puzzle/FireRoom/TilePuzzleSequenceChecker.cs` : Was updated
`Assets/Scripts/Puzzle/FireRoom/TorchPuzzleCheck.cs` : Was updated
`Assets/Scripts/Puzzle/MainRoom/DragonDoorPuzzle.cs` : Was updated
`Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs` : Was updated

## Testing

The feature / Bugfix can be testing by following these steps:

1. Assign the spell to unlock in the puzzle yourself
2. Do the puzzles, profit

Closes #229 
