### PR TITLE
✨ Unique spell charge

### DIFF
--- a/Assets/Scripts/Player/HandData.cs
+++ b/Assets/Scripts/Player/HandData.cs
@@ -61,9 +61,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
             _prefabContainer.SetActive(active);
         }
 
-        public void SetChargeEffect(VisualEffect chargeEffect)
+        public void SetChargeEffect(VisualEffectAsset chargeEffect)
         {
-            _chargeEffect.visualEffectAsset = chargeEffect.visualEffectAsset;
+            _chargeEffect.visualEffectAsset = chargeEffect;
         }
     }
 }

--- a/Assets/Scripts/Player/HandData.cs
+++ b/Assets/Scripts/Player/HandData.cs
@@ -60,5 +60,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player
         {
             _prefabContainer.SetActive(active);
         }
+
+        public void SetChargeEffect(VisualEffect chargeEffect)
+        {
+            _chargeEffect.visualEffectAsset = chargeEffect.visualEffectAsset;
+        }
     }
 }

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -269,16 +269,15 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
                 hand.TogglePrefabContainer(false);
         }
 
-        internal async UniTask ChargeEffect(HandData handData, float delay, VisualEffect chargeEffect)
+        internal async UniTask ChargeEffect(HandData handData, float delay, VisualEffectAsset chargeEffect)
         {
             if (handData._canCast)
             {
                 handData._lineRenderer.enabled = true;
                 handData.SetChargeEffect(chargeEffect);
-                chargeEffect.Play();
+                handData._chargeEffect.Play();
                 await UniTask.WaitForSeconds(delay, cancellationToken: _cancellationTokenSource.Token);
                 handData._lineRenderer.enabled = false;
-                chargeEffect.Stop();
             }
             else
                 handData._lineRenderer.enabled = false;

--- a/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
+++ b/Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs
@@ -5,6 +5,7 @@ using RogueApeStudios.SecretsOfIgnacios.Spells;
 using System;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.VFX;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
 {
@@ -268,14 +269,16 @@ namespace RogueApeStudios.SecretsOfIgnacios.Player.SpellMagicCircle
                 hand.TogglePrefabContainer(false);
         }
 
-        internal async UniTask ChargeEffect(HandData handData, float delay)
+        internal async UniTask ChargeEffect(HandData handData, float delay, VisualEffect chargeEffect)
         {
             if (handData._canCast)
             {
                 handData._lineRenderer.enabled = true;
-                handData._chargeEffect.Play();
+                handData.SetChargeEffect(chargeEffect);
+                chargeEffect.Play();
                 await UniTask.WaitForSeconds(delay, cancellationToken: _cancellationTokenSource.Token);
                 handData._lineRenderer.enabled = false;
+                chargeEffect.Stop();
             }
             else
                 handData._lineRenderer.enabled = false;

--- a/Assets/Scripts/Spells/Cast.cs
+++ b/Assets/Scripts/Spells/Cast.cs
@@ -54,8 +54,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
 
                     if (config._castType == CastTypes.Charged)
                     {
+                        HandConfig spell = handData.GetHandConfig(_spellManager, handData == _rightHandData);
                         _audioSource.Play();
-                        await _handVfxManager.ChargeEffect(handData, _castTimer);
+                        await _handVfxManager.ChargeEffect(handData, _castTimer, spell._chargeEffect);
                     }
 
                     ExecuteSpell(handData, config._castType);

--- a/Assets/Scripts/Spells/ScriptableObjects/Fire.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Fire.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
     _handMaterial: {fileID: 2100000, guid: c0790209a017c8b468b0e521aa03a646, type: 2}
     _handColor: {r: 1, g: 0.3810822, b: 0.10849059, a: 0.3137255}
     _poolSize: 6
-    _chargeEffect: {fileID: 0}
+    _chargeEffect: {fileID: 8926484042661614526, guid: 1b9b78b638cb9ac45bf1bdd8ae265fe7, type: 3}
     _audioClip: {fileID: 8300000, guid: c30d553f7efcc8443a40064e1e5a55e2, type: 3}
   _secondaryConfig:
     _elementType: 0

--- a/Assets/Scripts/Spells/ScriptableObjects/Wind.asset
+++ b/Assets/Scripts/Spells/ScriptableObjects/Wind.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
     _handMaterial: {fileID: -876546973899608171, guid: 682449b27d1db024aa354aa2d583de54, type: 3}
     _handColor: {r: 0, g: 1, b: 0.7221482, a: 0.3137255}
     _poolSize: 6
-    _chargeEffect: {fileID: 0}
+    _chargeEffect: {fileID: 8926484042661614526, guid: 1b9b78b638cb9ac45bf1bdd8ae265fe7, type: 3}
     _audioClip: {fileID: 8300000, guid: a951e4deb2361c94cb6545d671e81a3a, type: 3}
   _secondaryConfig:
     _elementType: 0

--- a/Assets/Scripts/Spells/Spell.cs
+++ b/Assets/Scripts/Spells/Spell.cs
@@ -17,7 +17,7 @@ namespace RogueApeStudios.SecretsOfIgnacios.Spells
         [SerializeField] internal Material _handMaterial;
         [SerializeField] internal Color _handColor;
         [SerializeField] internal int _poolSize;
-        [SerializeField] internal VisualEffect _chargeEffect;
+        [SerializeField] internal VisualEffectAsset _chargeEffect;
         [SerializeField] internal AudioClip _audioClip;
     }
 


### PR DESCRIPTION
## Content

Updated casting system to use the spells charge visual effect instead of a preset one. Air charge has not been added, I'm not artistic.

## Changes

### Updated
`Assets/Scripts/Player/HandData.cs` : Was updated / renamed. Added ability to set charge vfx.
`Assets/Scripts/Player/SpellMagicCircle/HandVfxManager.cs` : Was updated / renamed. Sets charge vfx.
`Assets/Scripts/Spells/Cast.cs` : Was updated / renamed. Provides correct vfx.
`Assets/Scripts/Spells/ScriptableObjects/Fire.asset` : Was updated / renamed. 
`Assets/Scripts/Spells/ScriptableObjects/Wind.asset` : Was updated / renamed. 
`Assets/Scripts/Spells/Spell.cs` : Was updated / renamed. VisualEffect field -> VisualEffectAsset field.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Set vfx in spell to different effect
2. Use spell
Note the vfx you set probably won't stop since they don't have a playtime and most likely loops

Closes #206 
