### PR TITLE
🐛 Earth door

### DIFF
--- a/Assets/Prefabs/SpellProjectiles/Fire Spell.prefab
+++ b/Assets/Prefabs/SpellProjectiles/Fire Spell.prefab
@@ -180,7 +180,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3798447849508435429, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
       propertyPath: spellName
-      value: Debug
+      value: Fire
       objectReference: {fileID: 0}
     - target: {fileID: 7032622482946899860, guid: f00636f4677cefe4cbe7ddc95c2f5e68, type: 3}
       propertyPath: m_CastShadows

--- a/Assets/Scripts/Interactables/Fire/FireInteractable.cs
+++ b/Assets/Scripts/Interactables/Fire/FireInteractable.cs
@@ -4,48 +4,48 @@ using UnityEngine.VFX;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Interactables.Fire
 {
-	internal abstract class FireInteractable : Interactables
-	{
-		[SerializeField] internal bool _getsDestroyed;
-		[SerializeField] internal bool _isOnFire;
+    internal abstract class FireInteractable : Interactables
+    {
+        [SerializeField] internal bool _getsDestroyed;
+        [SerializeField] internal bool _isOnFire;
 
-		[SerializeField] internal VisualEffect _burningEffect;
-		[SerializeField] internal VisualEffect _dousingEffect;
+        [SerializeField] internal VisualEffect _burningEffect;
+        [SerializeField] internal VisualEffect _dousingEffect;
 
-		internal event Action<bool> OnIgnitionToggle;
-		
-		internal override void Awake()
-		{
-			_spellReceiver.OnSpellReceived += HandleSpellReceived;
-		}
+        internal event Action<bool> OnIgnitionToggle;
 
-		internal override void OnDestroy()
-		{
-			_spellReceiver.OnSpellReceived -= HandleSpellReceived;
-		}
+        internal override void Awake()
+        {
+            _spellReceiver.OnSpellReceived += HandleSpellReceived;
+        }
+
+        internal override void OnDestroy()
+        {
+            _spellReceiver.OnSpellReceived -= HandleSpellReceived;
+        }
 
 
-		internal override void HandleSpellReceived(string spellType)
-		{
-			Debug.Log("Some fire spell hit");
-			switch (spellType)
-			{
-				case "Debug":
-					// Logic for casting a fire spell
-					OnFire();
-					OnIgnitionToggle?.Invoke(_isOnFire);
-					break;
-				case "Water":
-					// Logic for casting a water spell
-					OnDouse();
+        internal override void HandleSpellReceived(string spellType)
+        {
+            Debug.Log("Some fire spell hit");
+            switch (spellType)
+            {
+                case "Fire":
+                    // Logic for casting a fire spell
+                    OnFire();
+                    OnIgnitionToggle?.Invoke(_isOnFire);
+                    break;
+                case "Water":
+                    // Logic for casting a water spell
+                    OnDouse();
                     OnIgnitionToggle?.Invoke(!_isOnFire);
                     break;
-				default: throw new NotImplementedException();
-			}
-		}
+                default: throw new NotImplementedException();
+            }
+        }
 
-		internal abstract void OnFire();
+        internal abstract void OnFire();
 
-		internal abstract void OnDouse();
-	}
+        internal abstract void OnDouse();
+    }
 }

--- a/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
+++ b/Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs
@@ -1,9 +1,9 @@
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Fire;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Water;
 using RogueApeStudios.SecretsOfIgnacios.Interactables.Wind;
-using System.Collections.Generic;
 using RogueApeStudios.SecretsOfIgnacios.Progression;
 using RogueApeStudios.SecretsOfIgnacios.Spells;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
@@ -20,7 +20,9 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 
         [SerializeField] private List<GameObject> _areasToUnlock;
         [SerializeField] private Spell _spellToUnlock;
-        
+
+        private bool _opened = false;
+
         private void Awake()
         {
             _waterTarget.onFilled += TargetCheck;
@@ -37,15 +39,16 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
 
         private void TargetCheck(bool hit)
         {
-            if (_waterTarget._filled && _windTarget._isBlown && _fireTarget._isOnFire)
+            if (_waterTarget._filled && _windTarget._isBlown && _fireTarget._isOnFire && !_opened)
             {
+                _opened = true;
                 Debug.Log("Door opens");
                 _animator.SetTrigger("DubbleIn");
                 UnlockAreas();
                 UnlockSpell();
             }
         }
-        
+
         private void UnlockAreas()
         {
             foreach (var area in _areasToUnlock)
@@ -62,10 +65,10 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 }
             }
         }
-        
+
         private void UnlockSpell()
         {
-           if (_spellToUnlock != null)
+            if (_spellToUnlock != null)
             {
                 ProgressionData progressionData = new ProgressionData
                 {
@@ -76,6 +79,6 @@ namespace RogueApeStudios.SecretsOfIgnacios.Puzzle.MainRoom
                 ProgressionManager.TriggerProgressionEvent(progressionData);
             }
         }
-        
+
     }
 }

--- a/Assets/Scripts/Spells/CastScriptTester.cs
+++ b/Assets/Scripts/Spells/CastScriptTester.cs
@@ -1,0 +1,37 @@
+using Cysharp.Threading.Tasks;
+using System.Threading;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios.Spells
+{
+    public class CastScriptTester : MonoBehaviour
+    {
+        [SerializeField] private Cast _cast;
+        [SerializeField] private bool _fire;
+        [SerializeField] private GameObject _spell;
+        [SerializeField] private float _fireRate = 0.2f;
+
+        private CancellationTokenSource _cancellationTokenSource;
+
+        private void OnEnable()
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        private void OnDisable()
+        {
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+        }
+
+        public async void Go()
+        {
+            string _spellName = _spell.name;
+            while (_fire)
+            {
+                _cast.CastNoHands(transform, _spellName, _spell);
+                await UniTask.WaitForSeconds(_fireRate, cancellationToken: _cancellationTokenSource.Token);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Spells/CastScriptTester.cs.meta
+++ b/Assets/Scripts/Spells/CastScriptTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff8af8218fb8de44ca40373a791b9775

--- a/Assets/Scripts/Spells/Editor/CastScriptTesterEditor.cs
+++ b/Assets/Scripts/Spells/Editor/CastScriptTesterEditor.cs
@@ -1,0 +1,20 @@
+using RogueApeStudios.SecretsOfIgnacios.Spells;
+using UnityEditor;
+using UnityEngine;
+
+namespace RogueApeStudios.SecretsOfIgnacios
+{
+    [CustomEditor(typeof(CastScriptTester))]
+    public class CastScriptTesterEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            CastScriptTester myComponent = (CastScriptTester)target;
+
+            if (GUILayout.Button("Call GO"))
+                myComponent.Go();
+        }
+    }
+}

--- a/Assets/Scripts/Spells/Editor/CastScriptTesterEditor.cs.meta
+++ b/Assets/Scripts/Spells/Editor/CastScriptTesterEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2fd420d9fb5da5408dc20428f355ccc


### PR DESCRIPTION
## Content

Earth door now works correctly (not opening 3 times), also added a script to make testing easier.

## Changes
### Added
`Assets/Scripts/Spells/CastScriptTester.cs` : Was created. Can be used to cast spells from an empty transform.
`Assets/Scripts/Spells/Editor/CastScriptTesterEditor.cs` : Was created. Adds a button to the script in the editor.

### Updated
`Assets/Scripts/Puzzle/MainRoom/ElementDoorPuzzle.cs` : Was updated / renamed. Added a bool so the function doesn't keep triggering.
`Assets/Prefabs/SpellProjectiles/Fire Spell.prefab` : Was updated / renamed. Spell data value changed to Fire from Debug.
`Assets/Scripts/Interactables/Fire/FireInteractable.cs` : Was updated / renamed. Now checks for Fire instead of Debug.

## Testing

The feature / Bugfix can be testing by following these steps:

1. Create empty object with cast tester script, or go in VR
2. Hit the vents with the correct spells
3. Door go open wow

Closes #215, #216  
